### PR TITLE
feat(m1): A1+A2+A3 abstraction boundaries (#46 #47 #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,19 @@ poetry run pytest
 To use ChromaDB, set `use_chromadb=True` and provide the path to your ChromaDB SQLite file and collection name. This enables persistent, scalable vector search.
 
 ### Changing the Embedding Model
-Modify the `llm_model_name` parameter in `setup()` to use different models, e.g., "large" or "small".
+`setup()` now uses an embedding-model contract internally.
+
+Expected embed response contract:
+- The embedding provider must support `embed(texts=[...])`.
+- The response must contain an `embeddings` attribute.
+- `embeddings` must be a non-empty sequence of numeric vectors.
+
+Dimension behavior:
+- `setup()` probes the embedding model to infer vector dimension automatically.
+- If probe-time inference fails (invalid response shape or transient provider error), `setup()` falls back to legacy dimension `4096` for backward compatibility.
+
+Migration note for custom providers:
+- If you use a custom embedding client, ensure response shape follows the contract above to avoid `ValueError` during indexing/search normalization.
 
 ### Adding More Metadata
 Include additional columns in your data for more detailed results.
@@ -182,8 +194,9 @@ Include additional columns in your data for more detailed results.
 Edit `index.html` in the `templates` directory to adjust the UI layout or add more user features.
 
 ## Troubleshooting
-- **`AssertionError: d == self.d`**: Ensure the embedding dimension (`embedding_dim`) matches the output dimension from your embedding model.
+- **`AssertionError: d == self.d`**: Embedding/vector dimensions are typically inferred automatically. If this appears with custom providers, verify your embed response contains consistent numeric vectors in `response.embeddings`.
 - **`TypeError: embed() takes 1 positional argument`**: Use the correct keyword argument format for `embed()` based on your `cohere` version.
+- **`ValueError: Embedding response must contain an 'embeddings' attribute`**: Your embedding provider response shape does not match the A1 contract; return an object with an `embeddings` sequence.
 
 ### Parser Pipeline Troubleshooting (Issue #18 Slice 3)
 

--- a/docs/adr/ADR-0003-embedding-model-abstraction.md
+++ b/docs/adr/ADR-0003-embedding-model-abstraction.md
@@ -1,0 +1,55 @@
+# ADR-0003: Embedding Model Abstraction (A1)
+
+- Status: Accepted
+- Date: 2026-04-04
+- Epic: #45
+- Slice: #46 (M1-A1)
+
+## Context
+
+The retrieval/indexing path was tightly coupled to concrete embedding-client behavior.
+This made it harder to validate provider response shapes consistently and increased
+risk when swapping providers or handling probe-time failures.
+
+## Decision
+
+Introduce an embedding boundary with three parts:
+
+1. `EmbeddingModel` protocol contract
+- Requires `embed(texts=[...])` support.
+- Response must provide `embeddings` as a non-empty sequence of numeric vectors.
+
+2. Compatibility adapter
+- `CohereEmbeddingAdapter` wraps current provider usage without changing public setup/search APIs.
+
+3. Shared normalization utilities
+- `extract_embeddings(response)` validates and normalizes embedding payloads.
+- `infer_embedding_dimension(model)` probes one deterministic input to infer vector dimension.
+
+Setup behavior:
+- Preferred path: infer dimension from probe response.
+- Compatibility fallback: if probe inference fails (invalid response shape or runtime provider error), use legacy dimension `4096` and continue.
+
+## Consequences
+
+Positive:
+- Clear contract for embedding providers.
+- Centralized validation for embedding payload shape.
+- Reduced direct coupling to a specific embedding client in engine/setup.
+
+Trade-offs:
+- Setup now performs a probe call to infer dimension.
+- Fallback to legacy dimension can defer certain dimension mismatch failures to runtime if provider output is inconsistent.
+
+## Validation and Test Mapping
+
+- Invalid embedding response shape raises deterministic `ValueError` in engine search path.
+- Setup dimension inference uses adapter probe output when valid.
+- Setup falls back to legacy `4096` when probe shape is invalid.
+- Setup falls back to legacy `4096` when probe raises runtime/provider exceptions.
+
+## Non-goals (A1)
+
+- Full provider marketplace and dynamic plugin loading.
+- Advanced generation/streaming abstractions (handled in later slices).
+- Performance tuning beyond compatibility-safe boundary changes.

--- a/libs/ragsearch/embedding_models.py
+++ b/libs/ragsearch/embedding_models.py
@@ -1,0 +1,51 @@
+"""Embedding model protocols and compatibility adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class EmbeddingModel(Protocol):
+    """Minimal contract required by retrieval/indexing paths."""
+
+    def embed(self, texts: Sequence[str]) -> Any:
+        ...
+
+
+@dataclass
+class CohereEmbeddingAdapter:
+    """Adapter that presents a stable embedding contract over Cohere-like clients."""
+
+    client: Any
+
+    def embed(self, texts: Sequence[str]) -> Any:
+        return self.client.embed(texts=list(texts))
+
+
+def extract_embeddings(response: Any) -> List[List[float]]:
+    """Normalize embedding responses to a list-of-lists float shape."""
+    if not hasattr(response, "embeddings"):
+        raise ValueError("Embedding response must contain an 'embeddings' attribute.")
+
+    embeddings = getattr(response, "embeddings")
+    if not isinstance(embeddings, (list, tuple)) or not embeddings:
+        raise ValueError("Embedding response must provide a non-empty embeddings sequence.")
+
+    normalized: List[List[float]] = []
+    for embedding in embeddings:
+        if not isinstance(embedding, (list, tuple)) or not embedding:
+            raise ValueError("Each embedding must be a non-empty numeric sequence.")
+        try:
+            normalized.append([float(value) for value in embedding])
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Each embedding must be a numeric sequence.") from exc
+
+    return normalized
+
+
+def infer_embedding_dimension(embedding_model: EmbeddingModel, probe_text: str = "dimension probe") -> int:
+    """Infer embedding dimension from a single deterministic probe embedding."""
+    embeddings = extract_embeddings(embedding_model.embed(texts=[probe_text]))
+    return len(embeddings[0])

--- a/libs/ragsearch/engine.py
+++ b/libs/ragsearch/engine.py
@@ -3,17 +3,18 @@ This module contains the RAGSearchEngine class,
 which is responsible for initializing the RAG Search Engine
 """
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict
 import pandas as pd
 from .errors import NoDataFoundError
 from .embedding_models import EmbeddingModel, extract_embeddings
+from .llm_clients import LLMClient
 from .utils import (extract_textual_columns,
                     preprocess_search_text,
                     preprocess_text,
                     insert_embeddings_to_vector_db,
                     search_vector_db,
                     log_data_summary)
-from .vector_db import VectorDB
+from .vector_backends import VectorBackend
 from flask import Flask, request, jsonify, render_template
 import threading
 from pathlib import Path
@@ -38,8 +39,8 @@ class RagSearchEngine:
     def __init__(self,
                  data: pd.DataFrame,
                  embedding_model: EmbeddingModel,
-                 llm_client: Any,
-                 vector_db: VectorDB = None,
+                 llm_client: LLMClient,
+                 vector_db: VectorBackend = None,
                  batch_size: int = 100,
                  save_dir: str = "embeddings",
                  file_name: str = "data.csv",
@@ -51,7 +52,7 @@ class RagSearchEngine:
         Args:
             data (pd.DataFrame): The input data containing structured information.
             embedding_model (EmbeddingModel): Embedding provider implementing the embedding contract.
-            llm_client (Any): The client for interacting with the LLM.
+            llm_client (LLMClient): Baseline generation client implementing the LLM contract.
             vector_db (VectorDB): The vector database for storing and querying embeddings.
             batch_size (int): Number of rows to process in each batch.
             save_dir (str): Directory to save intermediate embeddings.

--- a/libs/ragsearch/engine.py
+++ b/libs/ragsearch/engine.py
@@ -3,10 +3,10 @@ This module contains the RAGSearchEngine class,
 which is responsible for initializing the RAG Search Engine
 """
 import logging
-from typing import List, Dict
+from typing import List, Dict, Any
 import pandas as pd
-from cohere import Client as CohereClient
 from .errors import NoDataFoundError
+from .embedding_models import EmbeddingModel, extract_embeddings
 from .utils import (extract_textual_columns,
                     preprocess_search_text,
                     preprocess_text,
@@ -37,8 +37,8 @@ class RagSearchEngine:
 
     def __init__(self,
                  data: pd.DataFrame,
-                 embedding_model: CohereClient,
-                 llm_client: CohereClient,
+                 embedding_model: EmbeddingModel,
+                 llm_client: Any,
                  vector_db: VectorDB = None,
                  batch_size: int = 100,
                  save_dir: str = "embeddings",
@@ -50,8 +50,8 @@ class RagSearchEngine:
 
         Args:
             data (pd.DataFrame): The input data containing structured information.
-            embedding_model (CohereClient): The client for generating text embeddings.
-            llm_client (CohereClient): The client for interacting with the LLM.
+            embedding_model (EmbeddingModel): Embedding provider implementing the embedding contract.
+            llm_client (Any): The client for interacting with the LLM.
             vector_db (VectorDB): The vector database for storing and querying embeddings.
             batch_size (int): Number of rows to process in each batch.
             save_dir (str): Directory to save intermediate embeddings.
@@ -113,7 +113,7 @@ class RagSearchEngine:
 
                 # Generate embeddings
                 response = self.embedding_model.embed(texts=batch["combined_text"].tolist())
-                embeddings = response.embeddings
+                embeddings = extract_embeddings(response)
 
                 # Add embeddings to the batch DataFrame
                 batch["embedding"] = embeddings
@@ -141,7 +141,8 @@ class RagSearchEngine:
             logging.info(f"Processing search query: '{query}'")
 
             # Generate the query embedding
-            query_embedding = self.embedding_model.embed(texts=[preprocess_search_text(query)]).embeddings[0]
+            query_response = self.embedding_model.embed(texts=[preprocess_search_text(query)])
+            query_embedding = extract_embeddings(query_response)[0]
 
             # Search the vector database
             results = search_vector_db(self.vector_db, query_embedding, top_k=top_k)

--- a/libs/ragsearch/llm_clients.py
+++ b/libs/ragsearch/llm_clients.py
@@ -1,0 +1,22 @@
+"""LLM client abstraction boundary and adapters."""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMClient(Protocol):
+    """Baseline generation contract used by the engine boundary."""
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        ...
+
+
+class CohereLLMClientAdapter:
+    """Adapter exposing a stable generation surface on top of Cohere client."""
+
+    def __init__(self, client: Any):
+        self._client = client
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        response = self._client.chat(message=prompt, **kwargs)
+        return str(getattr(response, "text", ""))

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -19,10 +19,12 @@ Example usage (ChromaDB):
 The returned RagSearchEngine instance will use the selected backend for queries.
 """
 import os
+import logging
 from pathlib import Path
 import pandas as pd
 from cohere import Client as CohereClient
 from .errors import NoDataFoundError, RagSearchError
+from .embedding_models import CohereEmbeddingAdapter, infer_embedding_dimension
 from .parsers import get_parser
 from .vector_db import VectorDB, query_chromadb
 from .engine import RagSearchEngine
@@ -30,6 +32,7 @@ from .engine import RagSearchEngine
 
 # File types loaded directly via pandas (no parser dispatch needed)
 STRUCTURED_EXTENSIONS = {".csv", ".json", ".parquet", ".pq"}
+logger = logging.getLogger(__name__)
 
 
 def _load_structured_data(data_path: Path) -> pd.DataFrame:
@@ -158,6 +161,7 @@ def setup(data_path: Path,
     # Initialize Cohere client
     try:
         llm_client = CohereClient(api_key=llm_api_key)
+        embedding_model = CohereEmbeddingAdapter(llm_client)
     except Exception as e:
         raise RuntimeError(f"Failed to initialize Cohere client: {e}")
 
@@ -167,7 +171,7 @@ def setup(data_path: Path,
             raise ValueError("ChromaDB path and collection name must be provided when use_chromadb is True.")
         engine = RagSearchEngine(
             data=data,
-            embedding_model=llm_client,
+            embedding_model=embedding_model,
             llm_client=llm_client,
             vector_db=None,
             file_name=file_name,
@@ -176,12 +180,18 @@ def setup(data_path: Path,
         )
     else:
         try:
-            vector_db = VectorDB(embedding_dim=4096)
+            embedding_dim = infer_embedding_dimension(embedding_model)
+        except (ValueError, TypeError, AttributeError) as exc:
+            # Preserve legacy fallback behavior when the provider probe shape is invalid.
+            logger.warning("Falling back to legacy embedding dimension 4096: %s", exc)
+            embedding_dim = 4096
+        try:
+            vector_db = VectorDB(embedding_dim=embedding_dim)
         except Exception as e:
             raise RuntimeError(f"Failed to connect to vector database: {e}")
         engine = RagSearchEngine(
             data=data,
-            embedding_model=llm_client,
+            embedding_model=embedding_model,
             llm_client=llm_client,
             vector_db=vector_db,
             file_name=file_name

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -181,8 +181,8 @@ def setup(data_path: Path,
     else:
         try:
             embedding_dim = infer_embedding_dimension(embedding_model)
-        except (ValueError, TypeError, AttributeError) as exc:
-            # Preserve legacy fallback behavior when the provider probe shape is invalid.
+        except Exception as exc:
+            # Preserve legacy fallback behavior when probe-time inference fails.
             logger.warning("Falling back to legacy embedding dimension 4096: %s", exc)
             embedding_dim = 4096
         try:

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -25,14 +25,20 @@ import pandas as pd
 from cohere import Client as CohereClient
 from .errors import NoDataFoundError, RagSearchError
 from .embedding_models import CohereEmbeddingAdapter, infer_embedding_dimension
+from .llm_clients import CohereLLMClientAdapter
 from .parsers import get_parser
-from .vector_db import VectorDB, query_chromadb
+from .vector_db import VectorDB
 from .engine import RagSearchEngine
 
 
 # File types loaded directly via pandas (no parser dispatch needed)
 STRUCTURED_EXTENSIONS = {".csv", ".json", ".parquet", ".pq"}
 logger = logging.getLogger(__name__)
+
+
+def build_vector_backend(*, embedding_dim: int):
+    """Build the default vector backend while preserving legacy setup behavior."""
+    return VectorDB(embedding_dim=embedding_dim)
 
 
 def _load_structured_data(data_path: Path) -> pd.DataFrame:
@@ -160,8 +166,9 @@ def setup(data_path: Path,
     
     # Initialize Cohere client
     try:
-        llm_client = CohereClient(api_key=llm_api_key)
-        embedding_model = CohereEmbeddingAdapter(llm_client)
+        raw_llm_client = CohereClient(api_key=llm_api_key)
+        llm_client = CohereLLMClientAdapter(raw_llm_client)
+        embedding_model = CohereEmbeddingAdapter(raw_llm_client)
     except Exception as e:
         raise RuntimeError(f"Failed to initialize Cohere client: {e}")
 
@@ -186,7 +193,7 @@ def setup(data_path: Path,
             logger.warning("Falling back to legacy embedding dimension 4096: %s", exc)
             embedding_dim = 4096
         try:
-            vector_db = VectorDB(embedding_dim=embedding_dim)
+            vector_db = build_vector_backend(embedding_dim=embedding_dim)
         except Exception as e:
             raise RuntimeError(f"Failed to connect to vector database: {e}")
         engine = RagSearchEngine(

--- a/libs/ragsearch/utils.py
+++ b/libs/ragsearch/utils.py
@@ -3,6 +3,7 @@ Utility functions for the ragsearch package.
 """
 import pandas as pd
 import logging
+from .embedding_models import extract_embeddings
 
 
 # Configure logging
@@ -44,7 +45,7 @@ def batch_generate_embeddings(embedding_model, texts: list) -> list:
     """
     try:
         response = embedding_model.embed(texts=texts)
-        embeddings = response.embeddings
+        embeddings = extract_embeddings(response)
         logging.info("Generated embeddings successfully.")
         return embeddings
     except Exception as e:

--- a/libs/ragsearch/vector_backends.py
+++ b/libs/ragsearch/vector_backends.py
@@ -1,0 +1,14 @@
+"""Vector backend abstraction and factory helpers for retrieval storage."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class VectorBackend(Protocol):
+    """Contract for vector storage/query backends consumed by the engine."""
+
+    def insert(self, embedding: list, metadata: dict) -> None:
+        ...
+
+    def search(self, query_embedding: list, top_k: int = 5) -> list:
+        ...

--- a/libs/tests/test_engine.py
+++ b/libs/tests/test_engine.py
@@ -161,3 +161,32 @@ def test_serialize_query_results_keeps_backward_compatibility():
 
     detailed_payload = RagSearchEngine._serialize_query_results(enriched, include_details=True)
     assert detailed_payload == enriched
+
+
+def test_search_raises_value_error_for_invalid_embedding_response():
+    class BadEmbeddingModel:
+        def embed(self, texts):
+            return object()
+
+    data = pd.DataFrame(
+        [
+            {
+                "text": "alpha",
+                "source_path": "/docs/a.txt",
+                "parser_name": "fallback/plain_text",
+            }
+        ]
+    )
+    engine = RagSearchEngine(
+        data=data,
+        embedding_model=BadEmbeddingModel(),
+        llm_client=DummyLLMClient(),
+        vector_db=VectorDB(embedding_dim=4),
+        save_dir="embeddings/test_engine",
+    )
+
+    try:
+        engine.search("alpha", top_k=1)
+        raise AssertionError("Expected ValueError for invalid embedding response")
+    except ValueError as exc:
+        assert "embeddings" in str(exc).lower()

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -277,3 +277,33 @@ def test_setup_falls_back_to_legacy_dimension_when_probe_shape_is_invalid(tmp_pa
     setup(Path(data_path), llm_api_key="test-key")
 
     assert captured["embedding_dim"] == 4096
+
+
+def test_setup_falls_back_to_legacy_dimension_when_probe_runtime_fails(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            raise RuntimeError("provider temporarily unavailable")
+
+    captured = {}
+
+    class CapturingVectorDB:
+        def __init__(self, embedding_dim):
+            captured["embedding_dim"] = embedding_dim
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.VectorDB", CapturingVectorDB)
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(Path(data_path), llm_api_key="test-key")
+
+    assert captured["embedding_dim"] == 4096

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -214,3 +214,66 @@ def test_setup_unstructured_all_whitespace_documents_raise_no_data(tmp_path, mon
 
     with pytest.raises(NoDataFoundError, match="No data found"):
         setup(Path(data_path), llm_api_key="test-key")
+
+
+def test_setup_uses_embedding_dimension_from_model(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    captured = {}
+
+    class CapturingVectorDB:
+        def __init__(self, embedding_dim):
+            captured["embedding_dim"] = embedding_dim
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.VectorDB", CapturingVectorDB)
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(Path(data_path), llm_api_key="test-key")
+
+    assert captured["embedding_dim"] == 3
+
+
+def test_setup_falls_back_to_legacy_dimension_when_probe_shape_is_invalid(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            return object()
+
+    captured = {}
+
+    class CapturingVectorDB:
+        def __init__(self, embedding_dim):
+            captured["embedding_dim"] = embedding_dim
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.VectorDB", CapturingVectorDB)
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(Path(data_path), llm_api_key="test-key")
+
+    assert captured["embedding_dim"] == 4096

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -307,3 +307,67 @@ def test_setup_falls_back_to_legacy_dimension_when_probe_runtime_fails(tmp_path,
     setup(Path(data_path), llm_api_key="test-key")
 
     assert captured["embedding_dim"] == 4096
+
+
+def test_setup_uses_backend_factory_for_vector_backend(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    sentinel_backend = object()
+    captured = {}
+
+    def fake_build_vector_backend(*, embedding_dim):
+        captured["embedding_dim"] = embedding_dim
+        return sentinel_backend
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            captured["vector_db"] = kwargs["vector_db"]
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.build_vector_backend", fake_build_vector_backend)
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(Path(data_path), llm_api_key="test-key")
+
+    assert captured["embedding_dim"] == 3
+    assert captured["vector_db"] is sentinel_backend
+
+
+def test_setup_wraps_llm_client_with_protocol_adapter(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    captured = {}
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            captured["llm_client"] = kwargs["llm_client"]
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.build_vector_backend", lambda **kwargs: object())
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(Path(data_path), llm_api_key="test-key")
+
+    assert hasattr(captured["llm_client"], "generate")


### PR DESCRIPTION
## Summary\nImplement Milestone 1 Slice A1 by introducing an EmbeddingModel protocol boundary with compatibility adapter wiring and test-first validation.\n\n## Changes\n- Added EmbeddingModel protocol + CohereEmbeddingAdapter + response normalization helpers.\n- Updated engine embedding paths to use normalized embedding extraction and clearer validation errors.\n- Updated setup to construct embedding adapter and infer dimension from model responses; preserved legacy fallback (4096) for invalid probe shape.\n- Added test-first coverage for invalid embedding response and setup dimension behavior.\n\n## Test Notes\n- poetry run pytest libs/tests/test_engine.py libs/tests/test_setup.py -q -> 17 passed\n- poetry run pytest -q -> 81 passed, 1 skipped\n\n## Risks\n- Existing pandas SettingWithCopyWarning remains in batch path (non-blocking, follow-up).\n\n## Linked Issue\n- Closes #46