### PR TITLE
feat(parser): LiteParse runtime failover to fallback parser (#45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 .DS_Store
+dataset/

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ rag_engine = setup(data_path, llm_api_key)
 Parser selection behavior:
 - LiteParse is preferred when available (Node.js + npx installed).
 - If LiteParse is unavailable, fallback parser is used for supported file types.
+- If LiteParse is selected but fails at runtime, `setup()` retries with fallback parser when the file type is fallback-supported.
 - Unsupported types raise `UnsupportedFileTypeError`.
 
 Note: supported extensions can be backend-dependent. LiteParse supports additional types such as `.doc`, `.png`, `.jpg`, and `.jpeg`, while fallback parsing is intentionally narrower.
@@ -203,8 +204,8 @@ Edit `index.html` in the `templates` directory to adjust the UI layout or add mo
 | Error | Typical Cause | Resolution |
 | --- | --- | --- |
 | `ParserUnavailableError: LiteParse CLI not found` | Node.js/npx not installed, or custom CLI path invalid | Install Node.js 18+, verify `npx` works, or set `RAGSEARCH_LITEPARSE_CLI` to a valid executable |
-| `ParseTimeoutError` | Large/complex document exceeded parse timeout | Retry with smaller file; timeout tuning via `LiteParseAdapter(timeout_s=...)` applies to custom parser flows, not the default `setup()` path |
-| `ParseCorruptError` | Corrupt file or invalid parser output payload | Validate file integrity and retry; inspect parser output/logs |
+| `ParseTimeoutError` | Large/complex document exceeded parse timeout | In default `setup()` flow, timeout may be recovered automatically via fallback parser for supported types; otherwise retry with smaller file and inspect parser logs |
+| `ParseCorruptError` | Corrupt file or invalid parser output payload | In default `setup()` flow, corruption may be recovered automatically via fallback parser for supported types; if both parsers fail, the primary LiteParse error is surfaced |
 | `UnsupportedFileTypeError` | Extension not supported by the active parser backend | Convert to a supported format; fallback supports `.txt/.md/.html/.htm/.pdf/.docx`, LiteParse supports additional formats |
 | `NoDataFoundError` | File parsed but content was empty/whitespace only | Verify source file contains readable text content |
 

--- a/docs/adr/ADR-0002-document-parsing-pipeline.md
+++ b/docs/adr/ADR-0002-document-parsing-pipeline.md
@@ -13,14 +13,16 @@ Issue #18 introduced parser boundary abstractions and setup-path integration for
 ## Decision
 1. `LiteParseAdapter` is the preferred parser when available.
 2. `FallbackParser` is used when LiteParse is unavailable and file type is supported.
-3. Parser selection is centralized in `get_parser()`.
-4. `setup()` routes structured files through pandas and unstructured files through parser dispatch.
-5. Empty or whitespace-only parsed content is filtered before indexing.
-6. Parser failures surface typed `RagSearchError` subclasses for predictable handling.
+3. When LiteParse is selected but fails at runtime, setup retries with `FallbackParser` for fallback-supported file types.
+4. Parser selection is centralized in `get_parser()`.
+5. `setup()` routes structured files through pandas and unstructured files through parser dispatch.
+6. Empty or whitespace-only parsed content is filtered before indexing.
+7. Parser failures surface typed `RagSearchError` subclasses for predictable handling.
 
 ## Consequences
 - Better extraction quality for complex formats when LiteParse is available.
 - Graceful degradation when LiteParse or optional parser dependencies are missing.
+- Improved runtime resiliency when LiteParse fails after selection and fallback can parse the same file type.
 - Deterministic error handling for timeout, corruption, unsupported type, and unavailable parser cases.
 - Existing structured ingestion flows remain unchanged.
 

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -23,10 +23,10 @@ import logging
 from pathlib import Path
 import pandas as pd
 from cohere import Client as CohereClient
-from .errors import NoDataFoundError, RagSearchError
+from .errors import NoDataFoundError, ParsingError, RagSearchError
 from .embedding_models import CohereEmbeddingAdapter, infer_embedding_dimension
 from .llm_clients import CohereLLMClientAdapter
-from .parsers import get_parser
+from .parsers import FallbackParser, LiteParseAdapter, get_parser
 from .vector_db import VectorDB
 from .engine import RagSearchEngine
 
@@ -68,7 +68,22 @@ def _load_unstructured_data(data_path: Path) -> pd.DataFrame:
     Integration point: Slice 1 parser contract (see docs/adr/ADR-0000-top-10-architecture-questions.md).
     """
     parser = get_parser(data_path)
-    documents = list(parser.parse(data_path))
+    try:
+        documents = list(parser.parse(data_path))
+    except ParsingError as exc:
+        # If LiteParse fails at runtime, attempt supported fallback parsing.
+        if isinstance(parser, LiteParseAdapter):
+            fallback = FallbackParser()
+            if fallback.supports(data_path):
+                logger.warning("LiteParse parsing failed; using fallback parser: %s", exc)
+                try:
+                    documents = list(fallback.parse(data_path))
+                except ParsingError as fallback_exc:
+                    raise exc from fallback_exc
+            else:
+                raise
+        else:
+            raise
     if not documents:
         raise NoDataFoundError(f"No data found in parsed input file: {data_path}")
 

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from libs.ragsearch.errors import NoDataFoundError, ParseTimeoutError, RagSearchError
+from libs.ragsearch.errors import NoDataFoundError, ParseCorruptError, ParseTimeoutError, RagSearchError
 from libs.ragsearch.parsers import ParsedDocument
+from libs.ragsearch.parsers._fallback import FallbackParser
+from libs.ragsearch.parsers._liteparse import LiteParseAdapter
 from libs.ragsearch.engine import RagSearchEngine
 from libs.ragsearch.setup import setup
 
@@ -307,6 +309,106 @@ def test_setup_falls_back_to_legacy_dimension_when_probe_runtime_fails(tmp_path,
     setup(Path(data_path), llm_api_key="test-key")
 
     assert captured["embedding_dim"] == 4096
+
+
+def test_setup_unstructured_uses_fallback_when_liteparse_runtime_fails(tmp_path, monkeypatch, caplog):
+    data_path = tmp_path / "sample.txt"
+    data_path.write_text("fallback parser content", encoding="utf-8")
+    caplog.set_level("WARNING")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    class DummyVectorDB:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    captured = {}
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            captured["data"] = kwargs["data"]
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.VectorDB", DummyVectorDB)
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    # Force LiteParse selection and runtime failure.
+    monkeypatch.setattr(LiteParseAdapter, "available", classmethod(lambda cls: True))
+
+    def raise_liteparse_error(self, path):
+        raise ParseTimeoutError("LiteParse timed out")
+
+    monkeypatch.setattr(LiteParseAdapter, "parse", raise_liteparse_error)
+    monkeypatch.setattr("libs.ragsearch.setup.get_parser", lambda path: LiteParseAdapter())
+
+    setup(Path(data_path), llm_api_key="test-key")
+
+    assert captured["data"].iloc[0]["text"] == "fallback parser content"
+    assert captured["data"].iloc[0]["parser_name"] == "fallback/plain_text"
+    assert "LiteParse parsing failed; using fallback parser" in caplog.text
+
+
+def test_setup_unstructured_reraises_primary_error_when_fallback_also_fails(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.txt"
+    data_path.write_text("input text", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr(LiteParseAdapter, "available", classmethod(lambda cls: True))
+
+    def raise_liteparse_error(self, path):
+        raise ParseTimeoutError("LiteParse timed out")
+
+    def raise_fallback_error(self, path):
+        raise ParseCorruptError("Fallback failed")
+
+    monkeypatch.setattr(LiteParseAdapter, "parse", raise_liteparse_error)
+    monkeypatch.setattr(FallbackParser, "parse", raise_fallback_error)
+    monkeypatch.setattr("libs.ragsearch.setup.get_parser", lambda path: LiteParseAdapter())
+
+    with pytest.raises(ParseTimeoutError, match="LiteParse timed out"):
+        setup(Path(data_path), llm_api_key="test-key")
+
+
+def test_setup_unstructured_fallback_primary_error_propagates(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.txt"
+    data_path.write_text("input text", encoding="utf-8")
+
+    class FailingFallbackParser(FallbackParser):
+        def parse(self, path):
+            raise ParseCorruptError("Fallback primary failed")
+
+    monkeypatch.setattr("libs.ragsearch.setup.get_parser", lambda path: FailingFallbackParser())
+
+    with pytest.raises(ParseCorruptError, match="Fallback primary failed"):
+        setup(Path(data_path), llm_api_key="test-key")
+
+
+def test_setup_unstructured_reraises_liteparse_error_when_fallback_unsupported(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.png"
+    data_path.write_text("binary-like placeholder", encoding="utf-8")
+
+    monkeypatch.setattr(LiteParseAdapter, "available", classmethod(lambda cls: True))
+
+    def raise_liteparse_error(self, path):
+        raise ParseTimeoutError("LiteParse timed out")
+
+    monkeypatch.setattr(LiteParseAdapter, "parse", raise_liteparse_error)
+    monkeypatch.setattr("libs.ragsearch.setup.get_parser", lambda path: LiteParseAdapter())
+
+    with pytest.raises(ParseTimeoutError, match="LiteParse timed out"):
+        setup(Path(data_path), llm_api_key="test-key")
 
 
 def test_setup_uses_backend_factory_for_vector_backend(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Add runtime failover for unstructured ingestion: when LiteParse is selected but fails with a parsing error, setup retries with FallbackParser for fallback-supported file types.

## Decision/Proposal
- Keep LiteParse as primary parser when available.
- Add additive reliability behavior in setup path only.
- Preserve original LiteParse exception when fallback also fails.

## Evidence/Test Notes
- Focused: poetry run pytest libs/tests/test_setup.py libs/tests/test_parsers.py -q => 44 passed
- Full: poetry run pytest -q => 88 passed, 1 skipped
- Added tests for runtime failover success, primary error preservation, unsupported fallback extension path, and fallback-primary propagation behavior.

## Risks
- Non-blocking pandas SettingWithCopyWarning remains in engine tests (existing warning debt).

## Next tasks with owners
- Maintainer: merge after checks/review.
- QA: monitor parser failover behavior on real datasets.
- UX Docs: keep parser behavior and troubleshooting docs synced with implementation.
