### PR TITLE
[#52] Ingestion reliability diagnostics in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Parser selection behavior:
 - If LiteParse is selected but fails at runtime, `setup()` retries with fallback parser when the file type is fallback-supported.
 - Unsupported types raise `UnsupportedFileTypeError`.
 
+Ingestion diagnostics:
+- After `setup()`, the engine exposes `rag_engine.ingestion_diagnostics` with deterministic per-file fields:
+    - `source_path`: input file path used for setup.
+    - `selected_parser`: `structured/pandas`, `liteparse`, or `fallback`.
+    - `status`: `success` or `recovered_with_fallback`.
+    - `failure_reason`: empty string on success; primary parser error message when fallback recovery is used.
+
 Note: supported extensions can be backend-dependent. LiteParse supports additional types such as `.doc`, `.png`, `.jpg`, and `.jpeg`, while fallback parsing is intentionally narrower.
 
 ### Step 3: Run a Search Query

--- a/docs/adr/ADR-0002-document-parsing-pipeline.md
+++ b/docs/adr/ADR-0002-document-parsing-pipeline.md
@@ -18,11 +18,13 @@ Issue #18 introduced parser boundary abstractions and setup-path integration for
 5. `setup()` routes structured files through pandas and unstructured files through parser dispatch.
 6. Empty or whitespace-only parsed content is filtered before indexing.
 7. Parser failures surface typed `RagSearchError` subclasses for predictable handling.
+8. `setup()` publishes deterministic per-file ingestion diagnostics on the engine (`ingestion_diagnostics`) with parser selection, status, and fallback failure reason.
 
 ## Consequences
 - Better extraction quality for complex formats when LiteParse is available.
 - Graceful degradation when LiteParse or optional parser dependencies are missing.
 - Improved runtime resiliency when LiteParse fails after selection and fallback can parse the same file type.
+- Improved operational clarity through deterministic ingestion diagnostics for each setup input.
 - Deterministic error handling for timeout, corruption, unsupported type, and unavailable parser cases.
 - Existing structured ingestion flows remain unchanged.
 

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -21,6 +21,7 @@ The returned RagSearchEngine instance will use the selected backend for queries.
 import os
 import logging
 from pathlib import Path
+from typing import Optional
 import pandas as pd
 from cohere import Client as CohereClient
 from .errors import NoDataFoundError, ParsingError, RagSearchError
@@ -51,7 +52,15 @@ def _load_structured_data(data_path: Path) -> pd.DataFrame:
     raise ValueError(f"Unsupported file type: {data_path.suffix}")
 
 
-def _load_unstructured_data(data_path: Path) -> pd.DataFrame:
+def _parser_label(parser) -> str:
+    if isinstance(parser, LiteParseAdapter):
+        return "liteparse"
+    if isinstance(parser, FallbackParser):
+        return "fallback"
+    return parser.__class__.__name__.lower()
+
+
+def _load_unstructured_data(data_path: Path, diagnostics: Optional[dict] = None) -> pd.DataFrame:
     """
     Load unstructured data (text, PDF, DOCX, etc.) by dispatching to parser via get_parser().
     
@@ -68,6 +77,8 @@ def _load_unstructured_data(data_path: Path) -> pd.DataFrame:
     Integration point: Slice 1 parser contract (see docs/adr/ADR-0000-top-10-architecture-questions.md).
     """
     parser = get_parser(data_path)
+    if diagnostics is not None:
+        diagnostics["selected_parser"] = _parser_label(parser)
     try:
         documents = list(parser.parse(data_path))
     except ParsingError as exc:
@@ -76,6 +87,10 @@ def _load_unstructured_data(data_path: Path) -> pd.DataFrame:
             fallback = FallbackParser()
             if fallback.supports(data_path):
                 logger.warning("LiteParse parsing failed; using fallback parser: %s", exc)
+                if diagnostics is not None:
+                    diagnostics["status"] = "recovered_with_fallback"
+                    diagnostics["failure_reason"] = str(exc)
+                    diagnostics["selected_parser"] = _parser_label(fallback)
                 try:
                     documents = list(fallback.parse(data_path))
                 except ParsingError as fallback_exc:
@@ -158,12 +173,20 @@ def setup(data_path: Path,
     if not data_path.exists():
         raise FileNotFoundError(f"Data path does not exist: {data_path}")
 
+    ingestion_diagnostics = {
+        "source_path": str(data_path),
+        "selected_parser": "",
+        "status": "success",
+        "failure_reason": "",
+    }
+
     # Load data with specific error handling
     try:
         if data_path.suffix in STRUCTURED_EXTENSIONS:
+            ingestion_diagnostics["selected_parser"] = "structured/pandas"
             data = _load_structured_data(data_path)
         else:
-            data = _load_unstructured_data(data_path)
+            data = _load_unstructured_data(data_path, diagnostics=ingestion_diagnostics)
     except RagSearchError:
         # Preserve RagSearchError from parser (NoDataFoundError, ParsingError, etc.)
         raise
@@ -220,4 +243,5 @@ def setup(data_path: Path,
         )
 
     print("Setup complete.")
+    engine.ingestion_diagnostics = ingestion_diagnostics
     return engine

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -311,6 +311,38 @@ def test_setup_falls_back_to_legacy_dimension_when_probe_runtime_fails(tmp_path,
     assert captured["embedding_dim"] == 4096
 
 
+def test_setup_exposes_structured_ingestion_diagnostics(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.build_vector_backend", lambda **kwargs: object())
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    engine = setup(Path(data_path), llm_api_key="test-key")
+
+    assert engine.ingestion_diagnostics == {
+        "source_path": str(data_path),
+        "selected_parser": "structured/pandas",
+        "status": "success",
+        "failure_reason": "",
+    }
+
+
 def test_setup_unstructured_uses_fallback_when_liteparse_runtime_fails(tmp_path, monkeypatch, caplog):
     data_path = tmp_path / "sample.txt"
     data_path.write_text("fallback parser content", encoding="utf-8")
@@ -349,11 +381,17 @@ def test_setup_unstructured_uses_fallback_when_liteparse_runtime_fails(tmp_path,
     monkeypatch.setattr(LiteParseAdapter, "parse", raise_liteparse_error)
     monkeypatch.setattr("libs.ragsearch.setup.get_parser", lambda path: LiteParseAdapter())
 
-    setup(Path(data_path), llm_api_key="test-key")
+    engine = setup(Path(data_path), llm_api_key="test-key")
 
     assert captured["data"].iloc[0]["text"] == "fallback parser content"
     assert captured["data"].iloc[0]["parser_name"] == "fallback/plain_text"
     assert "LiteParse parsing failed; using fallback parser" in caplog.text
+    assert engine.ingestion_diagnostics == {
+        "source_path": str(data_path),
+        "selected_parser": "fallback",
+        "status": "recovered_with_fallback",
+        "failure_reason": "LiteParse timed out",
+    }
 
 
 def test_setup_unstructured_reraises_primary_error_when_fallback_also_fails(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add deterministic per-file ingestion diagnostics in `setup()`
- preserve parser contracts while exposing selected parser, status, and fallback reason
- document diagnostics behavior in README and ADR-0002

## Changes
- `libs/ragsearch/setup.py`
  - add parser label normalization for diagnostics
  - track ingestion diagnostics through structured and unstructured paths
  - capture runtime LiteParse failure reason when fallback recovers
  - attach diagnostics to engine as `ingestion_diagnostics`
- `libs/tests/test_setup.py`
  - add diagnostics test for structured ingestion
  - extend fallback recovery test with diagnostics assertions
- `README.md`
  - document ingestion diagnostics fields and values
- `docs/adr/ADR-0002-document-parsing-pipeline.md`
  - record diagnostics publication decision and consequence

## Test Plan
- `pytest libs/tests/test_setup.py -q` => 19 passed
- `pytest -q` => 89 passed, 1 skipped

## Risks
- diagnostics currently live on runtime engine object only (not persisted)
- unrelated `SettingWithCopyWarning` in engine remains unchanged

Closes #52
