### PR TITLE
[#53] Embedding provider registry/factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,28 @@ To use ChromaDB, set `use_chromadb=True` and provide the path to your ChromaDB S
 ### Changing the Embedding Model
 `setup()` now uses an embedding-model contract internally.
 
+Provider selection (config-driven via `setup()` params):
+- `embedding_provider="cohere"` (default)
+- `embedding_provider="sentence_transformers"`
+- `embedding_provider="openai"`
+- `embedding_provider="ollama"`
+
+Optional provider settings:
+- `embedding_model_name`: provider-specific model id
+- `embedding_api_key`: embedding provider key (defaults to `llm_api_key`)
+- `embedding_base_url`: custom endpoint URL (OpenAI-compatible/Ollama host)
+
+Example:
+```python
+rag_engine = setup(
+    data_path,
+    llm_api_key,
+    embedding_provider="openai",
+    embedding_model_name="text-embedding-3-small",
+    embedding_api_key="your-openai-key",
+)
+```
+
 Expected embed response contract:
 - The embedding provider must support `embed(texts=[...])`.
 - The response must contain an `embeddings` attribute.
@@ -194,6 +216,11 @@ Dimension behavior:
 
 Migration note for custom providers:
 - If you use a custom embedding client, ensure response shape follows the contract above to avoid `ValueError` during indexing/search normalization.
+
+Optional dependencies for non-default providers:
+- `sentence-transformers` for `sentence_transformers`
+- `openai` for `openai`
+- `ollama` for `ollama`
 
 ### Adding More Metadata
 Include additional columns in your data for more detailed results.

--- a/docs/adr/ADR-0003-embedding-model-abstraction.md
+++ b/docs/adr/ADR-0003-embedding-model-abstraction.md
@@ -26,9 +26,15 @@ Introduce an embedding boundary with three parts:
 - `extract_embeddings(response)` validates and normalizes embedding payloads.
 - `infer_embedding_dimension(model)` probes one deterministic input to infer vector dimension.
 
+4. Provider registry/factory
+- Add `create_embedding_model(...)` to build provider adapters from setup configuration.
+- Phase-1 providers: `cohere` (default), `sentence_transformers`, `openai`, `ollama`.
+- Unknown provider selection fails fast with deterministic configuration errors.
+
 Setup behavior:
 - Preferred path: infer dimension from probe response.
 - Compatibility fallback: if probe inference fails (invalid response shape or runtime provider error), use legacy dimension `4096` and continue.
+- Setup remains backward-compatible: default embedding provider is Cohere when no provider is configured.
 
 ## Consequences
 
@@ -36,10 +42,12 @@ Positive:
 - Clear contract for embedding providers.
 - Centralized validation for embedding payload shape.
 - Reduced direct coupling to a specific embedding client in engine/setup.
+- Additive path to multimodel embeddings without changing search/indexing call sites.
 
 Trade-offs:
 - Setup now performs a probe call to infer dimension.
 - Fallback to legacy dimension can defer certain dimension mismatch failures to runtime if provider output is inconsistent.
+- Optional provider SDKs become environment-dependent when non-default providers are selected.
 
 ## Validation and Test Mapping
 

--- a/libs/ragsearch/embedding_models.py
+++ b/libs/ragsearch/embedding_models.py
@@ -6,12 +6,24 @@ from dataclasses import dataclass
 from typing import Any, List, Protocol, Sequence, runtime_checkable
 
 
+DEFAULT_SENTENCE_TRANSFORMERS_MODEL = "all-MiniLM-L6-v2"
+DEFAULT_OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"
+DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text"
+
+
 @runtime_checkable
 class EmbeddingModel(Protocol):
     """Minimal contract required by retrieval/indexing paths."""
 
     def embed(self, texts: Sequence[str]) -> Any:
         ...
+
+
+@dataclass
+class EmbeddingResponse:
+    """Normalized embedding response payload used by adapters."""
+
+    embeddings: List[List[float]]
 
 
 @dataclass
@@ -22,6 +34,125 @@ class CohereEmbeddingAdapter:
 
     def embed(self, texts: Sequence[str]) -> Any:
         return self.client.embed(texts=list(texts))
+
+
+@dataclass
+class OpenAIEmbeddingAdapter:
+    """Adapter for OpenAI embedding clients."""
+
+    client: Any
+    model: str = DEFAULT_OPENAI_EMBEDDING_MODEL
+
+    def embed(self, texts: Sequence[str]) -> EmbeddingResponse:
+        response = self.client.embeddings.create(model=self.model, input=list(texts))
+        raw_vectors = []
+        for item in getattr(response, "data", []):
+            if isinstance(item, dict):
+                raw_vectors.append(item.get("embedding"))
+            else:
+                raw_vectors.append(getattr(item, "embedding", None))
+        return EmbeddingResponse(embeddings=extract_embeddings(EmbeddingResponse(embeddings=raw_vectors)))
+
+
+@dataclass
+class SentenceTransformersEmbeddingAdapter:
+    """Adapter for sentence-transformers models."""
+
+    model: Any
+
+    def embed(self, texts: Sequence[str]) -> EmbeddingResponse:
+        encoded = self.model.encode(list(texts))
+        if hasattr(encoded, "tolist"):
+            encoded = encoded.tolist()
+        if isinstance(encoded, list) and encoded and not isinstance(encoded[0], list):
+            encoded = [encoded]
+        return EmbeddingResponse(embeddings=extract_embeddings(EmbeddingResponse(embeddings=encoded)))
+
+
+@dataclass
+class OllamaEmbeddingAdapter:
+    """Adapter for Ollama embedding clients."""
+
+    client: Any
+    model: str = DEFAULT_OLLAMA_EMBEDDING_MODEL
+
+    def embed(self, texts: Sequence[str]) -> EmbeddingResponse:
+        if hasattr(self.client, "embed"):
+            payload = self.client.embed(model=self.model, input=list(texts))
+            raw_vectors = payload.get("embeddings") if isinstance(payload, dict) else None
+            return EmbeddingResponse(embeddings=extract_embeddings(EmbeddingResponse(embeddings=raw_vectors)))
+
+        if hasattr(self.client, "embeddings"):
+            vectors: List[List[float]] = []
+            for text in texts:
+                payload = self.client.embeddings(model=self.model, prompt=text)
+                if isinstance(payload, dict):
+                    vector = payload.get("embedding")
+                else:
+                    vector = getattr(payload, "embedding", None)
+                vectors.append(vector)
+            return EmbeddingResponse(embeddings=extract_embeddings(EmbeddingResponse(embeddings=vectors)))
+
+        raise ValueError("Ollama client must provide either 'embed' or 'embeddings'.")
+
+
+def create_embedding_model(
+    provider: str = "cohere",
+    *,
+    api_key: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    cohere_client: Any | None = None,
+) -> EmbeddingModel:
+    """Build an embedding model adapter from provider configuration."""
+
+    normalized_provider = provider.strip().lower().replace("-", "_")
+
+    if normalized_provider == "cohere":
+        client = cohere_client
+        if client is None:
+            if not api_key:
+                raise ValueError("Cohere embedding provider requires api_key.")
+            try:
+                from cohere import Client as CohereClient
+            except ImportError as exc:
+                raise RuntimeError("Cohere SDK is not installed. Install package 'cohere'.") from exc
+            client = CohereClient(api_key=api_key)
+        return CohereEmbeddingAdapter(client)
+
+    if normalized_provider in {"sentence_transformers", "sentence-transformers"}:
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise RuntimeError(
+                "sentence-transformers is not installed. Install package 'sentence-transformers'."
+            ) from exc
+        return SentenceTransformersEmbeddingAdapter(SentenceTransformer(model or DEFAULT_SENTENCE_TRANSFORMERS_MODEL))
+
+    if normalized_provider == "openai":
+        if not api_key:
+            raise ValueError("OpenAI embedding provider requires api_key.")
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise RuntimeError("OpenAI SDK is not installed. Install package 'openai'.") from exc
+        return OpenAIEmbeddingAdapter(
+            client=OpenAI(api_key=api_key, base_url=base_url),
+            model=model or DEFAULT_OPENAI_EMBEDDING_MODEL,
+        )
+
+    if normalized_provider == "ollama":
+        try:
+            import ollama
+        except ImportError as exc:
+            raise RuntimeError("Ollama SDK is not installed. Install package 'ollama'.") from exc
+        client = ollama.Client(host=base_url) if base_url else ollama.Client()
+        return OllamaEmbeddingAdapter(client=client, model=model or DEFAULT_OLLAMA_EMBEDDING_MODEL)
+
+    raise ValueError(
+        "Unsupported embedding provider: "
+        f"{provider}. Supported providers: cohere, sentence_transformers, openai, ollama."
+    )
 
 
 def extract_embeddings(response: Any) -> List[List[float]]:

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -25,7 +25,7 @@ from typing import Optional
 import pandas as pd
 from cohere import Client as CohereClient
 from .errors import NoDataFoundError, ParsingError, RagSearchError
-from .embedding_models import CohereEmbeddingAdapter, infer_embedding_dimension
+from .embedding_models import create_embedding_model, infer_embedding_dimension
 from .llm_clients import CohereLLMClientAdapter
 from .parsers import FallbackParser, LiteParseAdapter, get_parser
 from .vector_db import VectorDB
@@ -137,7 +137,11 @@ def setup(data_path: Path,
           llm_api_key: str,
           use_chromadb: bool = False,
           chromadb_sqlite_path: str = None,
-          chromadb_collection_name: str = None):
+          chromadb_collection_name: str = None,
+          embedding_provider: str = "cohere",
+          embedding_model_name: Optional[str] = None,
+          embedding_api_key: Optional[str] = None,
+          embedding_base_url: Optional[str] = None):
     """
     Initializes the RAG search engine from structured or unstructured data.
 
@@ -151,6 +155,10 @@ def setup(data_path: Path,
         use_chromadb (bool): Whether to use ChromaDB instead of FAISS (default: False).
         chromadb_sqlite_path (str): Path to ChromaDB SQLite database (required if use_chromadb=True).
         chromadb_collection_name (str): ChromaDB collection name (required if use_chromadb=True).
+        embedding_provider (str): Embedding provider identifier (default: "cohere").
+        embedding_model_name (str): Optional provider-specific model name.
+        embedding_api_key (str): Optional API key for embedding provider; defaults to llm_api_key.
+        embedding_base_url (str): Optional base URL for provider endpoints (for OpenAI-compatible or Ollama hosts).
     Returns:
         RagSearchEngine: The initialized RAG search engine.
     Raises:
@@ -206,9 +214,19 @@ def setup(data_path: Path,
     try:
         raw_llm_client = CohereClient(api_key=llm_api_key)
         llm_client = CohereLLMClientAdapter(raw_llm_client)
-        embedding_model = CohereEmbeddingAdapter(raw_llm_client)
     except Exception as e:
         raise RuntimeError(f"Failed to initialize Cohere client: {e}")
+
+    try:
+        embedding_model = create_embedding_model(
+            provider=embedding_provider,
+            api_key=embedding_api_key or llm_api_key,
+            model=embedding_model_name,
+            base_url=embedding_base_url,
+            cohere_client=raw_llm_client if embedding_provider.strip().lower() == "cohere" else None,
+        )
+    except Exception as e:
+        raise RuntimeError(f"Failed to initialize embedding model: {e}") from e
 
     # Connect to vector database or ChromaDB
     if use_chromadb:

--- a/libs/tests/test_embedding_models.py
+++ b/libs/tests/test_embedding_models.py
@@ -1,0 +1,91 @@
+"""Tests for embedding provider adapters and factory behavior."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from libs.ragsearch.embedding_models import (
+    OllamaEmbeddingAdapter,
+    OpenAIEmbeddingAdapter,
+    SentenceTransformersEmbeddingAdapter,
+    create_embedding_model,
+    extract_embeddings,
+)
+
+
+class _OpenAIEmbeddingsClient:
+    def create(self, model, input):
+        assert model == "text-embedding-3-small"
+        assert input == ["a", "b"]
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(embedding=[0.1, 0.2, 0.3]),
+                SimpleNamespace(embedding=[0.4, 0.5, 0.6]),
+            ]
+        )
+
+
+class _OpenAIClient:
+    def __init__(self):
+        self.embeddings = _OpenAIEmbeddingsClient()
+
+
+class _SentenceTransformerModel:
+    def encode(self, texts):
+        assert texts == ["a", "b"]
+        return [[0.1, 0.2], [0.3, 0.4]]
+
+
+class _OllamaClient:
+    def embed(self, model, input):
+        assert model == "nomic-embed-text"
+        assert input == ["a", "b"]
+        return {"embeddings": [[0.1, 0.2], [0.3, 0.4]]}
+
+
+class _CohereLikeClient:
+    def embed(self, texts):
+        assert texts == ["probe"]
+        return SimpleNamespace(embeddings=[[0.9, 0.8]])
+
+
+def test_openai_adapter_normalizes_response_shape():
+    adapter = OpenAIEmbeddingAdapter(client=_OpenAIClient(), model="text-embedding-3-small")
+
+    response = adapter.embed(["a", "b"])
+
+    assert extract_embeddings(response) == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+def test_sentence_transformers_adapter_normalizes_response_shape():
+    adapter = SentenceTransformersEmbeddingAdapter(model=_SentenceTransformerModel())
+
+    response = adapter.embed(["a", "b"])
+
+    assert extract_embeddings(response) == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_ollama_adapter_normalizes_response_shape():
+    adapter = OllamaEmbeddingAdapter(client=_OllamaClient(), model="nomic-embed-text")
+
+    response = adapter.embed(["a", "b"])
+
+    assert extract_embeddings(response) == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_create_embedding_model_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unsupported embedding provider"):
+        create_embedding_model(provider="unknown")
+
+
+def test_create_embedding_model_requires_openai_api_key():
+    with pytest.raises(ValueError, match="requires api_key"):
+        create_embedding_model(provider="openai")
+
+
+def test_create_embedding_model_supports_injected_cohere_client():
+    model = create_embedding_model(provider="cohere", cohere_client=_CohereLikeClient())
+
+    response = model.embed(["probe"])
+
+    assert extract_embeddings(response) == [[0.9, 0.8]]

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -311,6 +311,74 @@ def test_setup_falls_back_to_legacy_dimension_when_probe_runtime_fails(tmp_path,
     assert captured["embedding_dim"] == 4096
 
 
+def test_setup_uses_configured_embedding_provider_factory(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class DummyEmbeddingModel:
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    captured = {}
+
+    def fake_create_embedding_model(provider, **kwargs):
+        captured["provider"] = provider
+        captured["model"] = kwargs.get("model")
+        captured["api_key"] = kwargs.get("api_key")
+        captured["base_url"] = kwargs.get("base_url")
+        return DummyEmbeddingModel()
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.create_embedding_model", fake_create_embedding_model)
+    monkeypatch.setattr("libs.ragsearch.setup.build_vector_backend", lambda **kwargs: object())
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(
+        Path(data_path),
+        llm_api_key="llm-key",
+        embedding_provider="openai",
+        embedding_model_name="text-embedding-3-small",
+        embedding_api_key="embedding-key",
+        embedding_base_url="https://api.openai.com/v1",
+    )
+
+    assert captured == {
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "api_key": "embedding-key",
+        "base_url": "https://api.openai.com/v1",
+    }
+
+
+def test_setup_raises_runtime_error_for_invalid_embedding_provider(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr(
+        "libs.ragsearch.setup.create_embedding_model",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("Unsupported embedding provider")),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to initialize embedding model"):
+        setup(Path(data_path), llm_api_key="test-key", embedding_provider="invalid")
+
+
 def test_setup_exposes_structured_ingestion_diagnostics(tmp_path, monkeypatch):
     data_path = tmp_path / "sample.csv"
     data_path.write_text("name,description\na,b\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add config-driven embedding provider registry/factory
- support phase-1 providers: Cohere (default), SentenceTransformers, OpenAI, Ollama
- preserve backward-compatible setup defaults and embedding contract

## Changes
- [libs/ragsearch/embedding_models.py](libs/ragsearch/embedding_models.py)
  - added provider adapters for OpenAI, SentenceTransformers, and Ollama
  - added `EmbeddingResponse` normalization payload
  - added `create_embedding_model(...)` factory with deterministic provider validation
- [libs/ragsearch/setup.py](libs/ragsearch/setup.py)
  - added setup params: `embedding_provider`, `embedding_model_name`, `embedding_api_key`, `embedding_base_url`
  - wired setup through embedding provider factory while keeping default behavior
- [libs/tests/test_embedding_models.py](libs/tests/test_embedding_models.py)
  - added adapter conformance tests for response shape and factory error semantics
- [libs/tests/test_setup.py](libs/tests/test_setup.py)
  - added setup wiring test for provider selection
  - added invalid provider configuration error-path test
- [README.md](README.md) and [docs/adr/ADR-0003-embedding-model-abstraction.md](docs/adr/ADR-0003-embedding-model-abstraction.md)
  - documented provider configuration and architecture update

## Test Plan
- `pytest libs/tests/test_embedding_models.py libs/tests/test_setup.py -q` => 27 passed
- `pytest -q` => 97 passed, 1 skipped

## Risks
- non-default providers require optional SDK dependencies at runtime
- LLM provider abstraction remains in #54 scope

Closes #53
