### PR TITLE
[#54] LLM provider registry/factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,36 @@ Optional dependencies for non-default providers:
 - `openai` for `openai`
 - `ollama` for `ollama`
 
+### Changing the LLM Provider
+`setup()` now uses a configurable LLM contract internally.
+
+Provider selection:
+- `llm_provider="cohere"` (default)
+- `llm_provider="openai"`
+- `llm_provider="ollama"`
+
+Optional provider settings:
+- `llm_model_name`: provider-specific chat model id
+- `llm_base_url`: custom endpoint URL (OpenAI-compatible/Ollama host)
+
+Example:
+```python
+rag_engine = setup(
+    data_path,
+    llm_api_key,
+    llm_provider="openai",
+    llm_model_name="gpt-4o-mini",
+    llm_base_url="https://api.openai.com/v1",
+)
+```
+
+Optional dependencies for non-default providers:
+- `openai` for `openai`
+- `ollama` for `ollama`
+
+Migration note:
+- Custom generation clients should return string output through the `generate(prompt, **kwargs)` contract to avoid runtime adaptation errors.
+
 ### Adding More Metadata
 Include additional columns in your data for more detailed results.
 

--- a/docs/adr/ADR-0004-llm-provider-registry.md
+++ b/docs/adr/ADR-0004-llm-provider-registry.md
@@ -1,0 +1,53 @@
+# ADR-0004: LLM Provider Registry/Factory
+
+- Status: Accepted
+- Date: 2026-04-04
+- Epic: #50
+- Slice: #54 (S3)
+
+## Context
+
+The generation boundary was still coupled to a single Cohere-specific adapter in setup. That made it difficult to configure alternative local or hosted LLM providers while keeping the engine contract stable.
+
+## Decision
+
+Introduce a provider registry/factory for generation clients:
+
+1. `LLMClient` remains the stable engine-facing contract.
+- Requires `generate(prompt, **kwargs) -> str`.
+
+2. `create_llm_client(...)` resolves provider configuration into an adapter.
+- Phase-1 providers: `cohere` (default), `openai`, `ollama`.
+- Unknown provider names fail fast with a deterministic configuration error.
+
+3. Provider-specific adapters normalize response shape.
+- `CohereLLMClientAdapter` preserves existing behavior.
+- `OpenAILLMClientAdapter` supports OpenAI chat/completions-style responses.
+- `OllamaLLMClientAdapter` supports Ollama chat/generate-style responses.
+
+4. `setup()` remains backward-compatible.
+- Existing callers can continue passing only `data_path` and `llm_api_key`.
+- Provider selection is additive through optional keyword arguments.
+
+## Consequences
+
+Positive:
+- Stable engine contract with provider-agnostic generation wiring.
+- Additive path for multimodel support without changing query/search call sites.
+- Clear failure mode for invalid provider configuration.
+
+Trade-offs:
+- Optional provider SDKs become environment-dependent when selected.
+- Response normalization assumptions must be kept in sync with provider SDK changes.
+
+## Testing Notes
+
+- Adapter tests verify response normalization and provider selection.
+- Setup tests verify factory wiring and invalid provider handling.
+- Full suite regression coverage remains required before merge.
+
+## Related
+
+- Issue #54
+- `libs/ragsearch/llm_clients.py`
+- `libs/ragsearch/setup.py`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ This folder stores Architecture Decision Records (ADRs) for ragsearch.
 
 - ADR-0002: document parsing pipeline
 - ADR-0003: embedding model abstraction
+- ADR-0004: llm provider registry/factory
 
 ## Conventions
 

--- a/libs/ragsearch/llm_clients.py
+++ b/libs/ragsearch/llm_clients.py
@@ -1,6 +1,13 @@
 """LLM client abstraction boundary and adapters."""
 
-from typing import Any, Protocol, runtime_checkable
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+DEFAULT_OPENAI_CHAT_MODEL = "gpt-4o-mini"
+DEFAULT_OLLAMA_CHAT_MODEL = "llama3.1"
 
 
 @runtime_checkable
@@ -20,3 +27,152 @@ class CohereLLMClientAdapter:
     def generate(self, prompt: str, **kwargs: Any) -> str:
         response = self._client.chat(message=prompt, **kwargs)
         return str(getattr(response, "text", ""))
+
+
+def _normalize_provider_name(provider: str) -> str:
+    return provider.strip().lower().replace("-", "_")
+
+
+def _extract_text_from_choice(choice: Any) -> str:
+    if isinstance(choice, dict):
+        message = choice.get("message") or choice.get("delta") or {}
+        if isinstance(message, dict):
+            return str(message.get("content", ""))
+        return str(getattr(message, "content", ""))
+
+    message = getattr(choice, "message", None) or getattr(choice, "delta", None)
+    if message is not None:
+        return str(getattr(message, "content", ""))
+    return str(getattr(choice, "text", ""))
+
+
+def _extract_openai_text(response: Any) -> str:
+    if isinstance(response, dict):
+        if response.get("output_text"):
+            return str(response.get("output_text", ""))
+        choices = response.get("choices") or []
+    else:
+        if getattr(response, "output_text", None):
+            return str(getattr(response, "output_text", ""))
+        choices = getattr(response, "choices", [])
+
+    if not choices:
+        return ""
+    return _extract_text_from_choice(choices[0])
+
+
+def _extract_ollama_text(response: Any) -> str:
+    if isinstance(response, dict):
+        if isinstance(response.get("message"), dict):
+            return str(response["message"].get("content", ""))
+        return str(response.get("response", ""))
+
+    message = getattr(response, "message", None)
+    if message is not None:
+        return str(getattr(message, "content", ""))
+    return str(getattr(response, "response", ""))
+
+
+@dataclass
+class OpenAILLMClientAdapter:
+    """Adapter for OpenAI chat/completions style clients."""
+
+    client: Any
+    model: str = DEFAULT_OPENAI_CHAT_MODEL
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        chat = getattr(self.client, "chat", None)
+        if chat is not None and hasattr(chat, "completions"):
+            response = chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                **kwargs,
+            )
+            return _extract_openai_text(response)
+
+        if hasattr(self.client, "responses"):
+            response = self.client.responses.create(
+                model=self.model,
+                input=prompt,
+                **kwargs,
+            )
+            return _extract_openai_text(response)
+
+        raise ValueError("OpenAI client must provide chat.completions.create or responses.create.")
+
+
+@dataclass
+class OllamaLLMClientAdapter:
+    """Adapter for Ollama generation clients."""
+
+    client: Any
+    model: str = DEFAULT_OLLAMA_CHAT_MODEL
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        if hasattr(self.client, "chat"):
+            response = self.client.chat(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                **kwargs,
+            )
+            return _extract_ollama_text(response)
+
+        if hasattr(self.client, "generate"):
+            response = self.client.generate(model=self.model, prompt=prompt, **kwargs)
+            return _extract_ollama_text(response)
+
+        raise ValueError("Ollama client must provide chat() or generate().")
+
+
+def create_llm_client(
+    provider: str = "cohere",
+    *,
+    api_key: Optional[str] = None,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    cohere_client: Optional[Any] = None,
+    openai_client: Optional[Any] = None,
+    ollama_client: Optional[Any] = None,
+) -> LLMClient:
+    """Build an LLM client adapter from provider configuration."""
+
+    normalized_provider = _normalize_provider_name(provider)
+
+    if normalized_provider == "cohere":
+        client = cohere_client
+        if client is None:
+            if not api_key:
+                raise ValueError("Cohere LLM provider requires api_key.")
+            try:
+                from cohere import Client as CohereClient
+            except ImportError as exc:
+                raise RuntimeError("Cohere SDK is not installed. Install package 'cohere'.") from exc
+            client = CohereClient(api_key=api_key)
+        return CohereLLMClientAdapter(client)
+
+    if normalized_provider == "openai":
+        client = openai_client
+        if client is None:
+            if not api_key:
+                raise ValueError("OpenAI LLM provider requires api_key.")
+            try:
+                from openai import OpenAI
+            except ImportError as exc:
+                raise RuntimeError("OpenAI SDK is not installed. Install package 'openai'.") from exc
+            client = OpenAI(api_key=api_key, base_url=base_url)
+        return OpenAILLMClientAdapter(client=client, model=model or DEFAULT_OPENAI_CHAT_MODEL)
+
+    if normalized_provider == "ollama":
+        client = ollama_client
+        if client is None:
+            try:
+                import ollama
+            except ImportError as exc:
+                raise RuntimeError("Ollama SDK is not installed. Install package 'ollama'.") from exc
+            client = ollama.Client(host=base_url) if base_url else ollama.Client()
+        return OllamaLLMClientAdapter(client=client, model=model or DEFAULT_OLLAMA_CHAT_MODEL)
+
+    raise ValueError(
+        "Unsupported LLM provider: "
+        f"{provider}. Supported providers: cohere, openai, ollama."
+    )

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -26,7 +26,7 @@ import pandas as pd
 from cohere import Client as CohereClient
 from .errors import NoDataFoundError, ParsingError, RagSearchError
 from .embedding_models import create_embedding_model, infer_embedding_dimension
-from .llm_clients import CohereLLMClientAdapter
+from .llm_clients import create_llm_client
 from .parsers import FallbackParser, LiteParseAdapter, get_parser
 from .vector_db import VectorDB
 from .engine import RagSearchEngine
@@ -34,7 +34,22 @@ from .engine import RagSearchEngine
 
 # File types loaded directly via pandas (no parser dispatch needed)
 STRUCTURED_EXTENSIONS = {".csv", ".json", ".parquet", ".pq"}
+SUPPORTED_EMBEDDING_PROVIDERS = {"cohere", "openai", "ollama", "sentence_transformers"}
+SUPPORTED_LLM_PROVIDERS = {"cohere", "openai", "ollama"}
 logger = logging.getLogger(__name__)
+
+
+def _normalize_provider_name(provider: str) -> str:
+    return provider.strip().lower().replace("-", "_")
+
+
+def _validate_provider(provider: str, supported: set[str], kind: str) -> str:
+    normalized = _normalize_provider_name(provider)
+    if normalized not in supported:
+        raise ValueError(
+            f"Unsupported {kind} provider: {provider}. Supported providers: {', '.join(sorted(supported))}."
+        )
+    return normalized
 
 
 def build_vector_backend(*, embedding_dim: int):
@@ -141,7 +156,10 @@ def setup(data_path: Path,
           embedding_provider: str = "cohere",
           embedding_model_name: Optional[str] = None,
           embedding_api_key: Optional[str] = None,
-          embedding_base_url: Optional[str] = None):
+          embedding_base_url: Optional[str] = None,
+          llm_provider: str = "cohere",
+          llm_model_name: Optional[str] = None,
+          llm_base_url: Optional[str] = None):
     """
     Initializes the RAG search engine from structured or unstructured data.
 
@@ -159,6 +177,9 @@ def setup(data_path: Path,
         embedding_model_name (str): Optional provider-specific model name.
         embedding_api_key (str): Optional API key for embedding provider; defaults to llm_api_key.
         embedding_base_url (str): Optional base URL for provider endpoints (for OpenAI-compatible or Ollama hosts).
+        llm_provider (str): LLM provider identifier (default: "cohere").
+        llm_model_name (str): Optional provider-specific chat model name.
+        llm_base_url (str): Optional base URL for provider endpoints (for OpenAI-compatible or Ollama hosts).
     Returns:
         RagSearchEngine: The initialized RAG search engine.
     Raises:
@@ -209,21 +230,42 @@ def setup(data_path: Path,
 
     # Get file name for logging/engine initialization
     file_name = data_path.name
-    
-    # Initialize Cohere client
+
     try:
-        raw_llm_client = CohereClient(api_key=llm_api_key)
-        llm_client = CohereLLMClientAdapter(raw_llm_client)
+        llm_provider_name = _validate_provider(llm_provider, SUPPORTED_LLM_PROVIDERS, "LLM")
+    except ValueError as e:
+        raise RuntimeError(f"Failed to initialize LLM client: {e}") from e
+
+    try:
+        embedding_provider_name = _validate_provider(embedding_provider, SUPPORTED_EMBEDDING_PROVIDERS, "embedding")
+    except ValueError as e:
+        raise RuntimeError(f"Failed to initialize embedding model: {e}") from e
+
+    cohere_client = None
+    if llm_provider_name == "cohere" or embedding_provider_name == "cohere":
+        try:
+            cohere_client = CohereClient(api_key=llm_api_key)
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize Cohere client: {e}")
+
+    try:
+        llm_client = create_llm_client(
+            provider=llm_provider_name,
+            api_key=llm_api_key,
+            model=llm_model_name,
+            base_url=llm_base_url,
+            cohere_client=cohere_client,
+        )
     except Exception as e:
-        raise RuntimeError(f"Failed to initialize Cohere client: {e}")
+        raise RuntimeError(f"Failed to initialize LLM client: {e}") from e
 
     try:
         embedding_model = create_embedding_model(
-            provider=embedding_provider,
+            provider=embedding_provider_name,
             api_key=embedding_api_key or llm_api_key,
             model=embedding_model_name,
             base_url=embedding_base_url,
-            cohere_client=raw_llm_client if embedding_provider.strip().lower() == "cohere" else None,
+            cohere_client=cohere_client,
         )
     except Exception as e:
         raise RuntimeError(f"Failed to initialize embedding model: {e}") from e

--- a/libs/tests/test_llm_clients.py
+++ b/libs/tests/test_llm_clients.py
@@ -1,0 +1,73 @@
+"""Tests for LLM provider adapters and factory behavior."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from libs.ragsearch.llm_clients import (
+    CohereLLMClientAdapter,
+    OllamaLLMClientAdapter,
+    OpenAILLMClientAdapter,
+    create_llm_client,
+)
+
+
+class _CohereClient:
+    def chat(self, message, **kwargs):
+        assert message == "hello"
+        return SimpleNamespace(text="cohere answer")
+
+
+class _OpenAIChatCompletions:
+    def create(self, model, messages, **kwargs):
+        assert model == "gpt-4o-mini"
+        assert messages == [{"role": "user", "content": "hello"}]
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="openai answer"))]
+        )
+
+
+class _OpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=_OpenAIChatCompletions())
+
+
+class _OllamaClient:
+    def chat(self, model, messages, **kwargs):
+        assert model == "llama3.1"
+        assert messages == [{"role": "user", "content": "hello"}]
+        return {"message": {"content": "ollama answer"}}
+
+
+def test_cohere_adapter_returns_text():
+    adapter = CohereLLMClientAdapter(_CohereClient())
+
+    assert adapter.generate("hello") == "cohere answer"
+
+
+def test_openai_adapter_returns_text():
+    adapter = OpenAILLMClientAdapter(client=_OpenAIClient())
+
+    assert adapter.generate("hello") == "openai answer"
+
+
+def test_ollama_adapter_returns_text():
+    adapter = OllamaLLMClientAdapter(client=_OllamaClient())
+
+    assert adapter.generate("hello") == "ollama answer"
+
+
+def test_create_llm_client_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unsupported LLM provider"):
+        create_llm_client(provider="unknown")
+
+
+def test_create_llm_client_requires_openai_api_key():
+    with pytest.raises(ValueError, match="requires api_key"):
+        create_llm_client(provider="openai")
+
+
+def test_create_llm_client_supports_injected_cohere_client():
+    model = create_llm_client(provider="cohere", cohere_client=_CohereClient())
+
+    assert model.generate("hello") == "cohere answer"

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -379,6 +379,85 @@ def test_setup_raises_runtime_error_for_invalid_embedding_provider(tmp_path, mon
         setup(Path(data_path), llm_api_key="test-key", embedding_provider="invalid")
 
 
+def test_setup_uses_configured_llm_provider_factory(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("CohereClient should not be initialized for non-Cohere LLM providers")
+
+    class DummyLLMClient:
+        def generate(self, prompt, **kwargs):
+            return "ok"
+
+    class DummyEmbeddingModel:
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    captured = {}
+
+    def fake_create_llm_client(provider, **kwargs):
+        captured["provider"] = provider
+        captured["model"] = kwargs.get("model")
+        captured["api_key"] = kwargs.get("api_key")
+        captured["base_url"] = kwargs.get("base_url")
+        return DummyLLMClient()
+
+    def fake_create_embedding_model(provider, **kwargs):
+        return DummyEmbeddingModel()
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            captured["llm_client"] = kwargs["llm_client"]
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.create_llm_client", fake_create_llm_client)
+    monkeypatch.setattr("libs.ragsearch.setup.create_embedding_model", fake_create_embedding_model)
+    monkeypatch.setattr("libs.ragsearch.setup.build_vector_backend", lambda **kwargs: object())
+    monkeypatch.setattr("libs.ragsearch.setup.RagSearchEngine", DummyEngine)
+
+    setup(
+        Path(data_path),
+        llm_api_key="llm-key",
+        llm_provider="openai",
+        llm_model_name="gpt-4o-mini",
+        llm_base_url="https://api.openai.com/v1",
+        embedding_provider="openai",
+    )
+
+    assert captured["provider"] == "openai"
+    assert captured["model"] == "gpt-4o-mini"
+    assert captured["api_key"] == "llm-key"
+    assert captured["base_url"] == "https://api.openai.com/v1"
+    assert isinstance(captured["llm_client"], DummyLLMClient)
+
+
+def test_setup_raises_runtime_error_for_invalid_llm_provider(tmp_path, monkeypatch):
+    data_path = tmp_path / "sample.csv"
+    data_path.write_text("name,description\na,b\n", encoding="utf-8")
+
+    class DummyCohereClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("CohereClient should not be initialized for invalid LLM provider config")
+
+    class DummyEmbeddingModel:
+        def embed(self, texts):
+            class Resp:
+                embeddings = [[0.1, 0.2, 0.3]]
+
+            return Resp()
+
+    monkeypatch.setattr("libs.ragsearch.setup.CohereClient", DummyCohereClient)
+    monkeypatch.setattr("libs.ragsearch.setup.create_embedding_model", lambda *args, **kwargs: DummyEmbeddingModel())
+
+    with pytest.raises(RuntimeError, match="Failed to initialize LLM client"):
+        setup(Path(data_path), llm_api_key="test-key", llm_provider="invalid")
+
+
 def test_setup_exposes_structured_ingestion_diagnostics(tmp_path, monkeypatch):
     data_path = tmp_path / "sample.csv"
     data_path.write_text("name,description\na,b\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add configurable LLM provider factory for generation clients
- support phase-1 providers: Cohere (default), OpenAI, Ollama
- preserve backward-compatible setup defaults and engine contract

## Changes
- [libs/ragsearch/llm_clients.py](libs/ragsearch/llm_clients.py)
  - added OpenAI and Ollama adapters
  - added `create_llm_client(...)` provider factory
  - normalized provider response extraction to stable string output
- [libs/ragsearch/setup.py](libs/ragsearch/setup.py)
  - added `llm_provider`, `llm_model_name`, and `llm_base_url` config options
  - validated provider names early and kept default Cohere behavior intact
- [libs/tests/test_llm_clients.py](libs/tests/test_llm_clients.py)
  - added adapter conformance tests for provider output normalization and factory errors
- [libs/tests/test_setup.py](libs/tests/test_setup.py)
  - added setup wiring tests for LLM provider selection and invalid-provider handling
- [README.md](README.md) and [docs/adr/ADR-0004-llm-provider-registry.md](docs/adr/ADR-0004-llm-provider-registry.md)
  - documented provider configuration and architecture decision
- [docs/adr/README.md](docs/adr/README.md)
  - added ADR-0004 to the active ADR index

## Test Plan
- `pytest libs/tests/test_llm_clients.py libs/tests/test_setup.py -q` => 29 passed
- `pytest -q` => 105 passed, 1 skipped

## Risks
- optional provider SDKs are required when non-default providers are selected
- response-shape normalization must stay aligned with provider SDK changes

Closes #54
