### PR TITLE
[#55] Retrieval-to-generation pipeline with citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ for result in results:
 # - excerpt: up to 200 chars from text/combined_text
 ```
 
+### Generate a Grounded Answer
+Use the retrieval-to-generation pipeline when you want a direct answer with preserved citations:
+
+```python
+response = rag_engine.answer("What does the document say about the accident location?", top_k=3)
+
+print(response["answer"])
+for citation in response["citations"]:
+    print(citation)
+```
+
+Answer response fields:
+- `question`: original query string
+- `answer`: generated response text
+- `results`: full retrieval results, including `metadata`, `citation`, and `similarity`
+- `citations`: citation list preserved from retrieval
+- `context`: grounded retrieval context supplied to the LLM
+
+HTTP API note:
+- `POST /answer` returns the same structured payload as `rag_engine.answer(...)`
+- `POST /query` remains backward-compatible and continues to return search results only
+
 ## Running the Web Interface
 ### Step 1: Start the Flask Server
 Run the following command to start the Flask server:

--- a/docs/adr/ADR-0005-retrieval-generation-pipeline.md
+++ b/docs/adr/ADR-0005-retrieval-generation-pipeline.md
@@ -1,0 +1,50 @@
+# ADR-0005: Retrieval-to-Generation Pipeline
+
+- Status: Accepted
+- Date: 2026-04-04
+- Epic: #50
+- Slice: #55 (S4)
+
+## Context
+
+The engine could retrieve relevant records and return citation-rich search results, but there was no first-class path to turn those retrieved records into a grounded natural-language answer while preserving the citation payload.
+
+## Decision
+
+Add an additive retrieval-to-generation pipeline on top of the existing search flow:
+
+1. `RagSearchEngine.answer(query, top_k=5)` generates a grounded answer.
+- It reuses `search()` to retrieve results.
+- It builds a deterministic prompt from the retrieved results.
+- It calls `llm_client.generate(prompt)` and returns a structured payload.
+
+2. Retrieval results remain the source of truth for citations.
+- The answer payload includes the original `results` and a flattened `citations` list.
+- Existing `search()` behavior remains unchanged.
+
+3. The public HTTP API is additive.
+- `/query` continues to serve search-only results.
+- `/answer` exposes the answer pipeline without changing legacy search consumers.
+
+## Consequences
+
+Positive:
+- Simple grounded-answer path built on existing retrieval primitives.
+- Citation payload is preserved and easy to inspect.
+- Backward compatibility is maintained for search consumers.
+
+Trade-offs:
+- The answer prompt is intentionally conservative and may be terse.
+- Any prompt schema changes should be coordinated with tests and documentation.
+
+## Testing Notes
+
+- Tests verify context assembly and prompt construction.
+- Tests verify answer output structure and citation preservation.
+- Search-only APIs remain covered by existing regression tests.
+
+## Related
+
+- Issue #55
+- `libs/ragsearch/engine.py`
+- `libs/ragsearch/llm_clients.py`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,7 @@ This folder stores Architecture Decision Records (ADRs) for ragsearch.
 - ADR-0002: document parsing pipeline
 - ADR-0003: embedding model abstraction
 - ADR-0004: llm provider registry/factory
+- ADR-0005: retrieval-to-generation pipeline
 
 ## Conventions
 

--- a/libs/ragsearch/engine.py
+++ b/libs/ragsearch/engine.py
@@ -3,7 +3,7 @@ This module contains the RAGSearchEngine class,
 which is responsible for initializing the RAG Search Engine
 """
 import logging
-from typing import List, Dict
+from typing import Any, Dict, List
 import pandas as pd
 from .errors import NoDataFoundError
 from .embedding_models import EmbeddingModel, extract_embeddings
@@ -197,6 +197,67 @@ class RagSearchEngine:
             return results
         return [res.get("metadata", {}) for res in results]
 
+    @staticmethod
+    def _build_answer_context(results: List[Dict]) -> str:
+        """Build a numbered retrieval context block for answer generation."""
+        if not results:
+            return ""
+
+        blocks = []
+        for position, result in enumerate(results, start=1):
+            citation = result.get("citation", {})
+            metadata = result.get("metadata", {})
+            excerpt = citation.get("excerpt") or metadata.get("text") or metadata.get("combined_text") or ""
+            source_path = citation.get("source_path", "")
+            parser_name = citation.get("parser_name", "")
+            similarity = result.get("similarity", 0.0)
+
+            blocks.append(
+                "\n".join(
+                    [
+                        f"[{position}] source_path: {source_path}",
+                        f"parser_name: {parser_name}",
+                        f"similarity: {similarity:.4f}",
+                        f"excerpt: {excerpt}",
+                    ]
+                )
+            )
+
+        return "\n\n".join(blocks)
+
+    @staticmethod
+    def _build_answer_prompt(query: str, results: List[Dict]) -> str:
+        """Construct a deterministic prompt for answer generation."""
+        context = RagSearchEngine._build_answer_context(results)
+        return "\n".join(
+            [
+                "You are a retrieval-augmented assistant.",
+                "Answer only from the provided sources.",
+                "If the sources are insufficient, say you do not know.",
+                "Cite sources inline using bracketed numbers like [1] or [1][2].",
+                "Keep the answer concise and grounded in the sources.",
+                "",
+                f"Question: {query}",
+                "",
+                "Sources:",
+                context or "(no sources retrieved)",
+            ]
+        )
+
+    def answer(self, query: str, top_k: int = 5) -> Dict[str, Any]:
+        """Generate a grounded answer with preserved retrieval citations."""
+        results = self.search(query, top_k=top_k)
+        prompt = self._build_answer_prompt(query, results)
+        answer_text = self.llm_client.generate(prompt)
+
+        return {
+            "question": query,
+            "answer": answer_text,
+            "results": results,
+            "citations": [result.get("citation", {}) for result in results],
+            "context": self._build_answer_context(results),
+        }
+
     def run(self):
         """
         Launches an interactive search interface where users can input queries and see results.
@@ -238,6 +299,16 @@ class RagSearchEngine:
             results = self.search(query, top_k=top_k)
             serialized = self._serialize_query_results(results, include_details=include_details)
             return jsonify({"results": serialized})
+
+        @app.route('/answer', methods=['POST'])
+        def answer():
+            request_data = request.get_json()
+            query = request_data.get('query')
+            if not query:
+                return jsonify({"error": "Query parameter is required"}), 400
+
+            top_k = int(request_data.get('top_k', 5))
+            return jsonify(self.answer(query, top_k=top_k))
 
         # Run the Flask app on a separate thread
         threading.Thread(target=app.run, kwargs={"host": "0.0.0.0", "port": 8080, "use_reloader": False}).start()

--- a/libs/tests/test_engine.py
+++ b/libs/tests/test_engine.py
@@ -30,7 +30,12 @@ class DummyEmbeddingModel:
 
 
 class DummyLLMClient:
-    pass
+    def __init__(self):
+        self.prompts = []
+
+    def generate(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        return "grounded answer"
 
 
 def _make_engine():
@@ -190,3 +195,43 @@ def test_search_raises_value_error_for_invalid_embedding_response():
         raise AssertionError("Expected ValueError for invalid embedding response")
     except ValueError as exc:
         assert "embeddings" in str(exc).lower()
+
+
+def test_build_answer_context_formats_retrieved_sources():
+    results = [
+        {
+            "metadata": {"text": "Alpha document content"},
+            "citation": {"source_path": "/docs/alpha.txt", "parser_name": "fallback/plain_text", "excerpt": "Alpha document content"},
+            "similarity": 0.93,
+        }
+    ]
+
+    context = RagSearchEngine._build_answer_context(results)
+
+    assert "[1] source_path: /docs/alpha.txt" in context
+    assert "parser_name: fallback/plain_text" in context
+    assert "similarity: 0.9300" in context
+    assert "excerpt: Alpha document content" in context
+
+
+def test_answer_returns_structured_output_with_preserved_citations():
+    engine = _make_engine()
+
+    payload = engine.answer("alpha", top_k=1)
+
+    assert payload["question"] == "alpha"
+    assert payload["answer"] == "grounded answer"
+    assert len(payload["results"]) == 1
+    assert payload["citations"] == [payload["results"][0]["citation"]]
+    assert "Question: alpha" in engine.llm_client.prompts[0]
+    assert "Sources:" in engine.llm_client.prompts[0]
+    assert "[1] source_path: /docs/alpha.txt" in engine.llm_client.prompts[0]
+
+
+def test_build_answer_prompt_mentions_grounding_rules():
+    prompt = RagSearchEngine._build_answer_prompt("What is alpha?", [])
+
+    assert "Answer only from the provided sources." in prompt
+    assert "If the sources are insufficient, say you do not know." in prompt
+    assert "Question: What is alpha?" in prompt
+    assert "(no sources retrieved)" in prompt


### PR DESCRIPTION
## Summary
- add retrieval-to-generation answer pipeline on top of existing search
- preserve citation payload in structured answer output
- keep `/query` backward-compatible and add additive `/answer` route

## Changes
- [libs/ragsearch/engine.py](libs/ragsearch/engine.py)
  - added `_build_answer_context()` and `_build_answer_prompt()` helpers
  - added `answer()` method that reuses retrieval results and returns structured output
  - added additive `/answer` HTTP route
- [libs/tests/test_engine.py](libs/tests/test_engine.py)
  - added context assembly, answer output, and citation-preservation tests
- [README.md](README.md)
  - documented answer pipeline usage and response schema
- [docs/adr/ADR-0005-retrieval-generation-pipeline.md](docs/adr/ADR-0005-retrieval-generation-pipeline.md)
  - recorded the answer pipeline decision
- [docs/adr/README.md](docs/adr/README.md)
  - indexed the new ADR

## Test Plan
- `pytest libs/tests/test_engine.py -q` => 9 passed
- `pytest -q` => 108 passed, 1 skipped

## Risks
- prompt wording is intentionally conservative and may need future tuning
- answer generation quality depends on the selected LLM provider

Closes #55
