### PR TITLE
[#56] Incremental indexing with changed-file detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # ragsearch
 
-`ragsearch` is a Python library designed for building a Retrieval-Augmented Generation (RAG) application that enables natural language querying over structured data. This tool leverages embedding models and a vector database (FAISS or ChromaDB) to provide an efficient and scalable search engine.
+`ragsearch` is a Python library designed for building a Retrieval-Augmented Generation (RAG) application that enables natural language querying over both structured and unstructured data. This tool leverages embedding models and a vector database (FAISS or ChromaDB) to provide an efficient and scalable search engine.
 
 ## Features
 - Seamless integration with the Cohere AI LLM for generating embeddings.
 - Utilizes FAISS for fast, in-memory vector storage and similarity search.
 - Optional ChromaDB backend for persistent, scalable vector search using SQLite.
 - Unstructured ingestion support through LiteParse (with Python fallback parsers).
+- Incremental indexing support for FAISS setup runs with changed-file detection and skip-unchanged behavior.
 - Easy setup and configuration for different use cases.
 - Simple web interface for user interaction.
 
@@ -123,6 +124,21 @@ Ingestion diagnostics:
     - `failure_reason`: empty string on success; primary parser error message when fallback recovery is used.
 
 Note: supported extensions can be backend-dependent. LiteParse supports additional types such as `.doc`, `.png`, `.jpg`, and `.jpeg`, while fallback parsing is intentionally narrower.
+
+Incremental indexing behavior (FAISS backend):
+- `setup()` persists an embedding manifest in the embeddings directory and reuses cached embeddings for unchanged records.
+- New or changed records are re-embedded, while unchanged records are skipped for embedding generation.
+- After setup, `rag_engine.ingestion_diagnostics["indexing"]` reports deterministic counters:
+    - `manifest_version`: manifest schema version.
+    - `manifest_path`: on-disk manifest file path.
+    - `total_records`: total records considered for indexing.
+    - `embedded_records`: records embedded in the current run.
+    - `reused_records`: records reused from manifest cache.
+    - `new_records`: records seen for the first time.
+    - `changed_records`: previously-seen records with changed content hash.
+
+Optional setup parameter:
+- `embeddings_dir`: custom directory for embedding artifacts and incremental manifest cache.
 
 ### Step 3: Run a Search Query
 Once the `ragsearch` is initialized, you can perform natural language searches.

--- a/docs/adr/ADR-0006-incremental-indexing-manifest.md
+++ b/docs/adr/ADR-0006-incremental-indexing-manifest.md
@@ -1,0 +1,44 @@
+# ADR-0006: Incremental indexing manifest and changed-file detection
+
+- Status: accepted
+- Date: 2026-04-04
+- Related issue: #56
+
+## Context
+
+Full re-embedding on every setup run is wasteful when most source records are unchanged.
+For the FAISS path, we need deterministic skip-unchanged behavior while keeping the in-memory
+vector index complete for each engine instance.
+
+## Decision
+
+Implement incremental indexing with an on-disk embedding manifest:
+
+- Persist a manifest under the embeddings directory with per-record content hash and embedding.
+- Compute deterministic cache keys per record and compare content hash to detect changes.
+- Reuse embeddings for unchanged records and generate embeddings only for new/changed records.
+- Rebuild the in-memory FAISS index on each run using a mix of reused and newly generated embeddings.
+- Expose deterministic indexing counters on `engine.indexing_diagnostics`, and include them in
+  `engine.ingestion_diagnostics["indexing"]` for setup consumers.
+
+## Consequences
+
+Positive:
+
+- Repeated setup runs avoid unnecessary embedding API calls for unchanged data.
+- Changed/new records are explicitly re-embedded, reducing stale-index risk.
+- Diagnostics provide deterministic observability for first-run, no-change rerun,
+  and changed-file rerun scenarios.
+
+Trade-offs:
+
+- Manifest files introduce local state management requirements.
+- Cache key strategy is tied to record ordering plus available source metadata.
+
+## Verification
+
+Tests cover:
+
+- first-run indexing (all records new)
+- no-change rerun (all records reused)
+- changed-record rerun (only changed records embedded)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,6 +8,7 @@ This folder stores Architecture Decision Records (ADRs) for ragsearch.
 - ADR-0003: embedding model abstraction
 - ADR-0004: llm provider registry/factory
 - ADR-0005: retrieval-to-generation pipeline
+- ADR-0006: incremental indexing manifest and changed-file detection
 
 ## Conventions
 

--- a/libs/ragsearch/engine.py
+++ b/libs/ragsearch/engine.py
@@ -3,6 +3,8 @@ This module contains the RAGSearchEngine class,
 which is responsible for initializing the RAG Search Engine
 """
 import logging
+import hashlib
+import json
 from typing import Any, Dict, List
 import pandas as pd
 from .errors import NoDataFoundError
@@ -67,6 +69,15 @@ class RagSearchEngine:
         self.file_name = file_name
         self.chromadb_sqlite_path = chromadb_sqlite_path
         self.chromadb_collection_name = chromadb_collection_name
+        self.indexing_diagnostics = {
+            "manifest_version": 1,
+            "manifest_path": "",
+            "total_records": 0,
+            "embedded_records": 0,
+            "reused_records": 0,
+            "new_records": 0,
+            "changed_records": 0,
+        }
 
         if self.data.empty:
             raise NoDataFoundError("No data found in the provided DataFrame.")
@@ -104,6 +115,15 @@ class RagSearchEngine:
         # Combine textual fields into a single text column
         self.data["combined_text"] = self.data.apply(lambda row: preprocess_text(row, textual_columns), axis=1)
 
+        manifest_path = self.save_dir / f"{self.file_name}.embedding_manifest.json"
+        manifest = self._load_embedding_manifest(manifest_path)
+
+        total_records = len(self.data)
+        embedded_records = 0
+        reused_records = 0
+        new_records = 0
+        changed_records = 0
+
         # Split data into batches
         batches = [self.data.iloc[i:i + self.batch_size] for i in range(0, len(self.data), self.batch_size)]
         logging.info(f"Data split into {len(batches)} batches (batch size: {self.batch_size})")
@@ -112,12 +132,48 @@ class RagSearchEngine:
             try:
                 logging.info(f"Processing batch {batch_idx + 1} with {len(batch)} records...")
 
-                # Generate embeddings
-                response = self.embedding_model.embed(texts=batch["combined_text"].tolist())
-                embeddings = extract_embeddings(response)
+                resolved_embeddings = []
+                pending_positions = []
+                pending_texts = []
+                pending_keys = []
+                pending_hashes = []
+
+                for _, row in batch.iterrows():
+                    record_key = self._record_cache_key(row)
+                    content_hash = self._content_hash(str(row.get("combined_text", "")))
+                    cached = manifest["records"].get(record_key)
+
+                    if cached and cached.get("content_hash") == content_hash:
+                        reused_records += 1
+                        resolved_embeddings.append(cached.get("embedding", []))
+                        continue
+
+                    pending_positions.append(len(resolved_embeddings))
+                    pending_texts.append(str(row.get("combined_text", "")))
+                    pending_keys.append(record_key)
+                    pending_hashes.append(content_hash)
+                    if cached:
+                        changed_records += 1
+                    else:
+                        new_records += 1
+                    resolved_embeddings.append(None)
+
+                if pending_texts:
+                    response = self.embedding_model.embed(texts=pending_texts)
+                    new_embeddings = extract_embeddings(response)
+                    embedded_records += len(new_embeddings)
+
+                    for offset, embedding in enumerate(new_embeddings):
+                        position = pending_positions[offset]
+                        resolved_embeddings[position] = embedding
+                        manifest["records"][pending_keys[offset]] = {
+                            "content_hash": pending_hashes[offset],
+                            "embedding": [float(value) for value in embedding],
+                        }
 
                 # Add embeddings to the batch DataFrame
-                batch["embedding"] = embeddings
+                batch = batch.copy()
+                batch["embedding"] = resolved_embeddings
 
                 # Insert embeddings and metadata into the vector database
                 metadata_columns = self.data.columns.difference(["embedding"]).tolist()
@@ -126,6 +182,69 @@ class RagSearchEngine:
                 logging.info(f"Batch {batch_idx + 1} successfully stored in the vector database.")
             except Exception as e:
                 logging.error(f"Failed to process batch {batch_idx + 1}: {e}")
+
+        self._save_embedding_manifest(manifest_path, manifest)
+        self.indexing_diagnostics = {
+            "manifest_version": int(manifest.get("version", 1)),
+            "manifest_path": str(manifest_path),
+            "total_records": int(total_records),
+            "embedded_records": int(embedded_records),
+            "reused_records": int(reused_records),
+            "new_records": int(new_records),
+            "changed_records": int(changed_records),
+        }
+
+    @staticmethod
+    def _content_hash(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _record_cache_key(row: pd.Series) -> str:
+        source_path = str(row.get("source_path", "")).strip()
+        parser_name = str(row.get("parser_name", "")).strip()
+        record_id = int(row.name)
+        if source_path:
+            return f"{source_path}::{parser_name}::{record_id}"
+        return f"row::{record_id}"
+
+    @staticmethod
+    def _load_embedding_manifest(manifest_path: Path) -> Dict[str, Any]:
+        if not manifest_path.exists():
+            return {"version": 1, "records": {}}
+
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {"version": 1, "records": {}}
+
+        records = payload.get("records") if isinstance(payload, dict) else None
+        if not isinstance(records, dict):
+            records = {}
+
+        normalized_records: Dict[str, Dict[str, Any]] = {}
+        for key, value in records.items():
+            if not isinstance(value, dict):
+                continue
+            content_hash = value.get("content_hash")
+            embedding = value.get("embedding")
+            if not isinstance(content_hash, str) or not isinstance(embedding, list):
+                continue
+            try:
+                normalized_embedding = [float(item) for item in embedding]
+            except (TypeError, ValueError):
+                continue
+            normalized_records[str(key)] = {
+                "content_hash": content_hash,
+                "embedding": normalized_embedding,
+            }
+
+        version = payload.get("version", 1) if isinstance(payload, dict) else 1
+        return {"version": int(version), "records": normalized_records}
+
+    @staticmethod
+    def _save_embedding_manifest(manifest_path: Path, manifest: Dict[str, Any]):
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
 
     def search(self, query: str, top_k: int = 5) -> List[Dict]:
         """

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -153,6 +153,7 @@ def setup(data_path: Path,
           use_chromadb: bool = False,
           chromadb_sqlite_path: str = None,
           chromadb_collection_name: str = None,
+          embeddings_dir: Optional[str] = None,
           embedding_provider: str = "cohere",
           embedding_model_name: Optional[str] = None,
           embedding_api_key: Optional[str] = None,
@@ -173,6 +174,7 @@ def setup(data_path: Path,
         use_chromadb (bool): Whether to use ChromaDB instead of FAISS (default: False).
         chromadb_sqlite_path (str): Path to ChromaDB SQLite database (required if use_chromadb=True).
         chromadb_collection_name (str): ChromaDB collection name (required if use_chromadb=True).
+        embeddings_dir (str): Optional directory for local embedding manifest/cache files.
         embedding_provider (str): Embedding provider identifier (default: "cohere").
         embedding_model_name (str): Optional provider-specific model name.
         embedding_api_key (str): Optional API key for embedding provider; defaults to llm_api_key.
@@ -280,6 +282,7 @@ def setup(data_path: Path,
             llm_client=llm_client,
             vector_db=None,
             file_name=file_name,
+            save_dir=embeddings_dir or "embeddings",
             chromadb_sqlite_path=chromadb_sqlite_path,
             chromadb_collection_name=chromadb_collection_name
         )
@@ -299,9 +302,11 @@ def setup(data_path: Path,
             embedding_model=embedding_model,
             llm_client=llm_client,
             vector_db=vector_db,
+            save_dir=embeddings_dir or "embeddings",
             file_name=file_name
         )
 
     print("Setup complete.")
+    ingestion_diagnostics["indexing"] = getattr(engine, "indexing_diagnostics", {})
     engine.ingestion_diagnostics = ingestion_diagnostics
     return engine

--- a/libs/tests/test_engine.py
+++ b/libs/tests/test_engine.py
@@ -38,6 +38,19 @@ class DummyLLMClient:
         return "grounded answer"
 
 
+class CountingEmbeddingModel:
+    def __init__(self):
+        self.call_sizes = []
+
+    def embed(self, texts):
+        self.call_sizes.append(len(texts))
+        vectors = []
+        for text in texts:
+            seed = float((sum(ord(ch) for ch in str(text)) % 10) + 1)
+            vectors.append([seed, seed / 2.0, seed / 3.0, seed / 4.0])
+        return DummyEmbeddingResponse(vectors)
+
+
 def _make_engine():
     data = pd.DataFrame(
         [
@@ -235,3 +248,105 @@ def test_build_answer_prompt_mentions_grounding_rules():
     assert "If the sources are insufficient, say you do not know." in prompt
     assert "Question: What is alpha?" in prompt
     assert "(no sources retrieved)" in prompt
+
+
+def test_incremental_indexing_first_run_marks_all_as_new(tmp_path):
+    data = pd.DataFrame(
+        [
+            {"text": "alpha", "source_path": "/docs/a.txt", "parser_name": "fallback/plain_text"},
+            {"text": "beta", "source_path": "/docs/b.txt", "parser_name": "fallback/plain_text"},
+        ]
+    )
+    model = CountingEmbeddingModel()
+
+    engine = RagSearchEngine(
+        data=data,
+        embedding_model=model,
+        llm_client=DummyLLMClient(),
+        vector_db=VectorDB(embedding_dim=4),
+        save_dir=str(tmp_path / "embeddings"),
+        file_name="incremental.csv",
+    )
+
+    assert model.call_sizes == [2]
+    assert engine.indexing_diagnostics["total_records"] == 2
+    assert engine.indexing_diagnostics["embedded_records"] == 2
+    assert engine.indexing_diagnostics["new_records"] == 2
+    assert engine.indexing_diagnostics["changed_records"] == 0
+    assert engine.indexing_diagnostics["reused_records"] == 0
+
+
+def test_incremental_indexing_no_change_rerun_reuses_cached_embeddings(tmp_path):
+    data = pd.DataFrame(
+        [
+            {"text": "alpha", "source_path": "/docs/a.txt", "parser_name": "fallback/plain_text"},
+            {"text": "beta", "source_path": "/docs/b.txt", "parser_name": "fallback/plain_text"},
+        ]
+    )
+
+    first_model = CountingEmbeddingModel()
+    RagSearchEngine(
+        data=data.copy(),
+        embedding_model=first_model,
+        llm_client=DummyLLMClient(),
+        vector_db=VectorDB(embedding_dim=4),
+        save_dir=str(tmp_path / "embeddings"),
+        file_name="incremental.csv",
+    )
+
+    second_model = CountingEmbeddingModel()
+    second_engine = RagSearchEngine(
+        data=data.copy(),
+        embedding_model=second_model,
+        llm_client=DummyLLMClient(),
+        vector_db=VectorDB(embedding_dim=4),
+        save_dir=str(tmp_path / "embeddings"),
+        file_name="incremental.csv",
+    )
+
+    assert second_model.call_sizes == []
+    assert second_engine.indexing_diagnostics["embedded_records"] == 0
+    assert second_engine.indexing_diagnostics["new_records"] == 0
+    assert second_engine.indexing_diagnostics["changed_records"] == 0
+    assert second_engine.indexing_diagnostics["reused_records"] == 2
+
+
+def test_incremental_indexing_reindexes_only_changed_records(tmp_path):
+    baseline = pd.DataFrame(
+        [
+            {"text": "alpha", "source_path": "/docs/a.txt", "parser_name": "fallback/plain_text"},
+            {"text": "beta", "source_path": "/docs/b.txt", "parser_name": "fallback/plain_text"},
+        ]
+    )
+    updated = pd.DataFrame(
+        [
+            {"text": "alpha updated", "source_path": "/docs/a.txt", "parser_name": "fallback/plain_text"},
+            {"text": "beta", "source_path": "/docs/b.txt", "parser_name": "fallback/plain_text"},
+        ]
+    )
+
+    first_model = CountingEmbeddingModel()
+    RagSearchEngine(
+        data=baseline,
+        embedding_model=first_model,
+        llm_client=DummyLLMClient(),
+        vector_db=VectorDB(embedding_dim=4),
+        save_dir=str(tmp_path / "embeddings"),
+        file_name="incremental.csv",
+    )
+
+    second_model = CountingEmbeddingModel()
+    second_engine = RagSearchEngine(
+        data=updated,
+        embedding_model=second_model,
+        llm_client=DummyLLMClient(),
+        vector_db=VectorDB(embedding_dim=4),
+        save_dir=str(tmp_path / "embeddings"),
+        file_name="incremental.csv",
+    )
+
+    assert second_model.call_sizes == [1]
+    assert second_engine.indexing_diagnostics["embedded_records"] == 1
+    assert second_engine.indexing_diagnostics["new_records"] == 0
+    assert second_engine.indexing_diagnostics["changed_records"] == 1
+    assert second_engine.indexing_diagnostics["reused_records"] == 1

--- a/libs/tests/test_setup.py
+++ b/libs/tests/test_setup.py
@@ -487,6 +487,7 @@ def test_setup_exposes_structured_ingestion_diagnostics(tmp_path, monkeypatch):
         "selected_parser": "structured/pandas",
         "status": "success",
         "failure_reason": "",
+        "indexing": {},
     }
 
 
@@ -538,6 +539,7 @@ def test_setup_unstructured_uses_fallback_when_liteparse_runtime_fails(tmp_path,
         "selected_parser": "fallback",
         "status": "recovered_with_fallback",
         "failure_reason": "LiteParse timed out",
+        "indexing": {},
     }
 
 


### PR DESCRIPTION
## Summary
- add incremental indexing for FAISS runs using a persisted embedding manifest
- detect changed/new records via content hash and only embed those records
- expose deterministic indexing counters via engine.indexing_diagnostics and ingestion_diagnostics["indexing"]
- add tests for first-run indexing, no-change rerun, and changed-record rerun
- document incremental behavior and unstructured-data support updates in README
- add ADR-0006 for manifest and changed-file detection strategy

## Decision or Proposal
- Use a per-record cache key + SHA256 content hash to drive skip-unchanged behavior.
- Rebuild in-memory index every run, but reuse cached embeddings for unchanged records.
- Keep behavior additive and backward-compatible for existing setup/search/answer flows.

## Evidence or Test Notes
- Focused: /Users/mj/Developer/Personal_Codespace /RAGSearch Package/ragsearch/.venv/bin/python -m pytest libs/tests/test_engine.py libs/tests/test_setup.py -q -> 35 passed
- Full: /Users/mj/Developer/Personal_Codespace /RAGSearch Package/ragsearch/.venv/bin/python -m pytest -q -> 111 passed, 1 skipped

## Risks
- Cache key strategy depends on stable record ordering plus source metadata.
- Corrupt/invalid manifest payloads are treated as cache misses and regenerated.

## Next tasks with owners
- QA: verify rerun behavior across representative datasets.
- Maintainer: review manifest-path expectations in deployment/runtime environments.
- UX Docs: expand operations guidance with incremental rerun examples.
