### PR TITLE
ci: fix release workflow failure on Python 3.14

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
Fixes failing release workflow run:
https://github.com/mrutunjay-kinagi/ragsearch/actions/runs/24314519985/job/70989805736

## Root cause
The publish workflow used actions/setup-python with python-version '3.x', which resolved to Python 3.14 in GitHub Actions.
poetry install then failed while building pydantic-core because the PyO3 build path in that dependency stack does not support 3.14 in this run.

## Change
- Update .github/workflows/python-publish.yml:
  - actions/setup-python@v3 -> actions/setup-python@v5
  - python-version: '3.x' -> python-version: '3.11'

## Expected outcome
Release workflow installs dependencies and proceeds to tests/docs/build/publish without the Python 3.14 + PyO3 failure.
