### PR TITLE
release: v0.1.4

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Release v0.1.4: workflow fix, ready for PyPI publish.\n- Fix: Pin Python 3.11 in release workflow for PyO3 compatibility.\n- Bump: Version to 0.1.4 for new release.\n- All tests and builds pass.\n- Next: Merge, tag, and publish to PyPI.