### PR TITLE
chore: fix logging, silent failures, and dev dependency grouping

### DIFF
--- a/libs/ragsearch/config.py
+++ b/libs/ragsearch/config.py
@@ -4,9 +4,6 @@ config.py - Load and parse configuration data from a JSON
 import json
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 def load_configuration(file_path: str) -> dict:
     """
     Load and parse configuration data from a JSON or YAML file.

--- a/libs/ragsearch/engine.py
+++ b/libs/ragsearch/engine.py
@@ -25,9 +25,6 @@ from flask import Flask, request, jsonify, render_template
 import threading
 from pathlib import Path
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 class RagSearchEngine:
     @staticmethod
     def _normalize_optional_text(value) -> str:
@@ -143,6 +140,7 @@ class RagSearchEngine:
         batches = [self.index_data.iloc[i:i + self.batch_size] for i in range(0, len(self.index_data), self.batch_size)]
         logging.info(f"Data split into {len(batches)} batches (batch size: {self.batch_size})")
 
+        batch_errors = []
         for batch_idx, batch in enumerate(batches):
             try:
                 logging.info(f"Processing batch {batch_idx + 1} with {len(batch)} records...")
@@ -197,6 +195,14 @@ class RagSearchEngine:
                 logging.info(f"Batch {batch_idx + 1} successfully stored in the vector database.")
             except Exception as e:
                 logging.error(f"Failed to process batch {batch_idx + 1}: {e}")
+                batch_errors.append((batch_idx + 1, e))
+
+        if batch_errors:
+            failed = ", ".join(f"batch {i}" for i, _ in batch_errors)
+            raise RuntimeError(
+                f"Embedding indexing failed for {len(batch_errors)} batch(es): {failed}. "
+                f"First error: {batch_errors[0][1]}"
+            ) from batch_errors[0][1]
 
         self._save_embedding_manifest(manifest_path, manifest)
         self.indexing_diagnostics = {

--- a/libs/ragsearch/setup.py
+++ b/libs/ragsearch/setup.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from time import perf_counter
 from typing import Optional
 import pandas as pd
-from cohere import Client as CohereClient
 from .errors import NoDataFoundError, ParsingError, RagSearchError
 from .embedding_models import create_embedding_model, infer_embedding_dimension
 from .llm_clients import create_llm_client
@@ -203,7 +202,7 @@ def setup(data_path: Path,
         RagSearchError: If unstructured parser fails (UnsupportedFileTypeError, ParsingError, etc.).
         RuntimeError: For other data loading, Cohere client, or vector database errors.
     """
-    print("Starting setup of the RAG Search Engine...")
+    logger.info("Starting setup of the RAG Search Engine...")
     setup_started = perf_counter()
 
     # Validate data_path type
@@ -256,9 +255,12 @@ def setup(data_path: Path,
     cohere_client = None
     if llm_provider_name == "cohere" or embedding_provider_name == "cohere":
         try:
+            from cohere import Client as CohereClient
             cohere_client = CohereClient(api_key=llm_api_key)
+        except ImportError as e:
+            raise RuntimeError("Cohere SDK is not installed. Install package 'cohere'.") from e
         except Exception as e:
-            raise RuntimeError(f"Failed to initialize Cohere client: {e}")
+            raise RuntimeError(f"Failed to initialize Cohere client: {e}") from e
 
     try:
         llm_client = create_llm_client(
@@ -322,7 +324,7 @@ def setup(data_path: Path,
             file_name=file_name
         )
 
-    print("Setup complete.")
+    logger.info("Setup complete.")
     setup_latency_ms = round((perf_counter() - setup_started) * 1000.0, 3)
     ingestion_diagnostics["observability"] = {
         "stage": "ingestion",

--- a/libs/ragsearch/utils.py
+++ b/libs/ragsearch/utils.py
@@ -6,9 +6,6 @@ import logging
 from .embedding_models import extract_embeddings
 
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 def extract_textual_columns(data: pd.DataFrame) -> list:
     """
     Extract columns containing textual data from a DataFrame.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ragsearch"
-version = "0.1.4"
+version = "0.1.5"
 description = "ragsearch is a Python library designed for building a Retrieval-Augmented Generation (RAG) application that enables natural language querying over both structured and unstructured data. This tool leverages embedding models and a vector database (FAISS or ChromaDB) to provide an efficient and scalable search engine."
 authors = ["Mrutunjay Kinagi < mrutunjay.kinagi @ gmail.com >"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,21 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytest = "^8.3.3"
-sphinx = "7.4.7"
-sphinx-rtd-theme = "^3.0.2"
-myst-parser = "^2.0.0"
-pylint = "^3.3.1"
 flask = "^3.1.2"
 cohere = "^5.17.0"
 faiss-cpu = {version = "^1.12.0", python = ">=3.9,<3.15"}
 pandas = "^2.2.3"
 chromadb = "^1.0.20"
 fastavro = "^1.12.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.3"
+pylint = "^3.3.1"
+
+[tool.poetry.group.docs.dependencies]
+sphinx = "7.4.7"
+sphinx-rtd-theme = "^3.0.2"
+myst-parser = "^2.0.0"
 
 
 [build-system]


### PR DESCRIPTION
## Summary

- **Remove `logging.basicConfig()` from library modules** (`engine.py`, `utils.py`, `config.py`) — calling `basicConfig` at import time hijacks the host application's logging configuration
- **Replace `print()` with `logger.info()`** in `setup.py` — libraries should not write to stdout
- **Make Cohere import lazy** in `setup.py` — consistent with all other provider adapters; users who only use OpenAI or Ollama no longer get an import-time error if `cohere` isn't installed
- **Surface batch embedding failures** in `engine.py` — previously a failed batch was logged and silently skipped, leaving the index incomplete with no signal to the caller; failures now raise a `RuntimeError` after the loop
- **Move dev/docs deps to separate groups** in `pyproject.toml` — `pytest`, `pylint`, `sphinx` and related packages are now in `[tool.poetry.group.dev]` and `[tool.poetry.group.docs]` so end users don't install them as runtime dependencies

## Test plan

- [x] Run existing test suite: `pytest libs/tests/`
- [x] Verify `import ragsearch` does not configure root logger
- [x] Verify setup with a non-Cohere provider works without `cohere` installed
- [x] Verify a failing embedding batch raises `RuntimeError` rather than silently completing
- [x] Confirm `poetry install` (without `--with dev`) excludes pytest/pylint/sphinx

🤖 Generated with [Claude Code](https://claude.com/claude-code)